### PR TITLE
More clearly define support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.3"
   - "3.4"
 install: pip install tox-travis
 script: tox

--- a/README.md
+++ b/README.md
@@ -45,9 +45,26 @@ In your templates, use your component by first importing the django_components t
 
 # Running the tests
 
-Install and run `tox`:
+Install `tox`:
 
 ```sh
 pip install tox
+```
+
+Then run all the tests over all Python versions:
+
+```sh
 tox
+```
+
+Or just the particular version you wish to test:
+
+```sh
+tox -e py34
+```
+
+You can also have it watch the directory for changes and re-run the tests:
+
+```sh
+tox -e py34 -- -f
 ```

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
         'Private :: Do Not Upload',
     ],
     install_requires=[
-        'Django>=1.5'
+        'Django>=1.8'
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist = py27, py34
+envlist = py{27,33,34}
 
 [testenv]
 deps =
     pytest
+    pytest-xdist
 commands = py.test {posargs}


### PR DESCRIPTION
This started out as a plan to support Django 1.7 and 1.8, and on all
current versions of Python. This turned into supporting Django 1.8 on
Python 2.7, 3.3, and 3.4 only.

The tests don't pass under Django 1.7 because 1.8 introduced new
settings for configuring templates. Because of this the install_requires
section of setup.py declares that it must be using Django 1.8+.

Python 3.3 support was added, since that's a supported version of Python
under Django 1.8.

Also added pytest-xdist to the tox dependencies, to support running

    tox -e py34 -- -f

in order to have it watch and rerun the tests in development.