### PR TITLE
Add Django 1.7 to the build matrix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
         'Private :: Do Not Upload',
     ],
     install_requires=[
-        'Django>=1.8'
+        'Django>=1.7'
     ],
 )

--- a/tests/django_test_setup.py
+++ b/tests/django_test_setup.py
@@ -2,11 +2,20 @@ import django
 from django.conf import settings
 
 if not settings.configured:
-    settings.configure(
-        INSTALLED_APPS=('django_components',),
-        TEMPLATES=[{
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': ["tests/templates/"],
-        }]
-    )
+    # Django 1.8 changes how you set up templates, so use different
+    # settings for different Django versions
+    if django.VERSION >= (1, 8):
+        settings.configure(
+            INSTALLED_APPS=('django_components',),
+            TEMPLATES=[{
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': ["tests/templates/"],
+            }]
+        )
+    else:
+        settings.configure(
+            INSTALLED_APPS=('django_components',),
+            TEMPLATE_DIRS=["tests/templates/"],
+        )
+
     django.setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,15 @@
 [tox]
-envlist = py{27,33,34}
+envlist = py{27,33,34}-django{17,18}
+
+[tox:travis]
+2.7 = py27-django{17,18}
+3.3 = py33-django{17,18}
+3.4 = py34-django{17,18}
 
 [testenv]
 deps =
     pytest
     pytest-xdist
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
 commands = py.test {posargs}


### PR DESCRIPTION
This has tox running two tests per box, in tox. It's good for now, but we may want to adjust that in the future to make them all run on their own run from the Travis build matrix.