### PR TITLE
Add Django classifier to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
+        "Framework :: Django"
     ],
 )


### PR DESCRIPTION
setup.py does not set the `Framework :: Django` classifier which makes it less discoverable by potential new users.