### PR TITLE
Rework of context handling

### DIFF
--- a/django_components/component.py
+++ b/django_components/component.py
@@ -7,7 +7,6 @@ from six import with_metaclass
 # Allow "component.AlreadyRegistered" instead of having to import these everywhere
 from django_components.component_registry import AlreadyRegistered, ComponentRegistry, NotRegistered  # noqa
 
-
 # Django < 2.1 compatibility
 try:
     from django.template.base import TokenType

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -7,11 +7,6 @@ from six import with_metaclass
 # Allow "component.AlreadyRegistered" instead of having to import these everywhere
 from django_components.component_registry import AlreadyRegistered, ComponentRegistry, NotRegistered  # noqa
 
-# Python 2 compatibility
-try:
-    from inspect import getfullargspec
-except ImportError:
-    from inspect import getargspec as getfullargspec
 
 # Django < 2.1 compatibility
 try:

--- a/tests/templates/incrementer.html
+++ b/tests/templates/incrementer.html
@@ -1,0 +1,2 @@
+{% load component_tags %}<p class="incrementer">value={{ value }};calls={{ calls }}</p>
+{% slot 'content' %}{% endslot %}

--- a/tests/templates/parent_template.html
+++ b/tests/templates/parent_template.html
@@ -1,0 +1,12 @@
+{% load component_tags %}
+
+<div>
+    <h1>Parent content</h1>
+    {% component name="variable_display" shadowing_variable='override' new_variable='unique_val' %}
+</div>
+<div>
+    {% slot 'content' %}
+        <h2>Slot content</h2>
+        {% component name="variable_display" shadowing_variable='slot_default_override' new_variable='slot_default_unique' %}
+    {% endslot %}
+</div>

--- a/tests/templates/parent_with_args_template.html
+++ b/tests/templates/parent_with_args_template.html
@@ -1,0 +1,12 @@
+{% load component_tags %}
+
+<div>
+    <h1>Parent content</h1>
+    {% component name="variable_display" shadowing_variable=inner_parent_value new_variable='unique_val' %}
+</div>
+<div>
+    {% slot 'content' %}
+        <h2>Slot content</h2>
+        {% component name="variable_display" shadowing_variable='slot_default_override' new_variable=inner_parent_value %}
+    {% endslot %}
+</div>

--- a/tests/templates/variable_display.html
+++ b/tests/templates/variable_display.html
@@ -1,0 +1,4 @@
+{% load component_tags %}
+
+<h1>Shadowing variable = {{ shadowing_variable }}</h1>
+<h1>Uniquely named variable = {{ unique_variable }}</h1>

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,5 +1,7 @@
 from textwrap import dedent
 
+from django.template import Context
+
 from django_components import component
 
 from .django_test_setup import *  # NOQA
@@ -29,13 +31,14 @@ class ComponentRegistryTest(SimpleTestCase):
                 js = ["script.js"]
 
         comp = SimpleComponent()
+        context = Context(comp.context(variable="test"))
 
         self.assertHTMLEqual(comp.render_dependencies(), dedent("""
             <link href="style.css" type="text/css" media="all" rel="stylesheet">
             <script src="script.js"></script>
         """).strip())
 
-        self.assertHTMLEqual(comp.render(variable="test"), dedent("""
+        self.assertHTMLEqual(comp.render(context), dedent("""
             Variable: <strong>test</strong>
         """).lstrip())
 
@@ -66,8 +69,9 @@ class ComponentRegistryTest(SimpleTestCase):
                 return "filtered_template.html"
 
         comp = FilteredComponent()
+        context = Context(comp.context(var1="test1", var2="test2"))
 
-        self.assertHTMLEqual(comp.render(var1="test1", var2="test2"), dedent("""
+        self.assertHTMLEqual(comp.render(context), dedent("""
             Var1: <strong>test1</strong>
             Var2 (uppercased): <strong>TEST2</strong>
         """).lstrip())

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -151,7 +151,8 @@ class ContextTests(SimpleTestCase):
 class ParentArgsTests(SimpleTestCase):
     def test_parent_args_can_be_drawn_from_context(self):
         template = Template("{% load component_tags %}{% component_dependencies %}"
-                            "{% component_block 'parent_with_args' parent_value=parent_value %}{%endcomponent_block %}")
+                            "{% component_block 'parent_with_args' parent_value=parent_value %}"
+                            "{% endcomponent_block %}")
         rendered = template.render(Context({'parent_value': 'passed_in'}))
 
         self.assertIn('<h1>Shadowing variable = passed_in</h1>', rendered, rendered)
@@ -224,4 +225,3 @@ class ContextCalledOnceTests(SimpleTestCase):
         rendered = template.render(Context()).strip()
 
         self.assertEqual(rendered, '<p class="incrementer">value=4;calls=1</p>\n<p>slot</p>', rendered)
-

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,227 @@
+from django.template import Context, Template
+
+from django_components import component
+
+from .django_test_setup import *  # NOQA
+from .testutils import Django111CompatibleSimpleTestCase as SimpleTestCase
+
+
+class ParentComponent(component.Component):
+    def context(self):
+        return {
+            "shadowing_variable": 'NOT SHADOWED'
+        }
+
+    def template(self, context):
+        return "parent_template.html"
+
+
+class ParentComponentWithArgs(component.Component):
+    def context(self, parent_value):
+        return {
+            "inner_parent_value": parent_value
+        }
+
+    def template(self, context):
+        return "parent_with_args_template.html"
+
+
+class VariableDisplay(component.Component):
+    def context(self, shadowing_variable, new_variable):
+        return {
+            "shadowing_variable": shadowing_variable,
+            "unique_variable": new_variable
+        }
+
+    def template(self, context):
+        return "variable_display.html"
+
+
+class IncrementerComponent(component.Component):
+    def context(self, value=0):
+        value = int(value)
+        if hasattr(self, 'call_count'):
+            self.call_count += 1
+        else:
+            self.call_count = 1
+        return {
+            "value": value + 1,
+            "calls": self.call_count
+        }
+
+    def template(self, context):
+        return "incrementer.html"
+
+
+component.registry.register(name='parent_component', component=ParentComponent)
+component.registry.register(name='parent_with_args', component=ParentComponentWithArgs)
+component.registry.register(name='variable_display', component=VariableDisplay)
+component.registry.register(name='incrementer', component=IncrementerComponent)
+
+
+class ContextTests(SimpleTestCase):
+    def test_nested_component_context_shadows_parent_with_unfilled_slots_and_component_tag(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component 'parent_component' %}")
+        rendered = template.render(Context())
+
+        self.assertIn('<h1>Shadowing variable = override</h1>', rendered, rendered)
+        self.assertIn('<h1>Shadowing variable = slot_default_override</h1>', rendered, rendered)
+        self.assertNotIn('<h1>Shadowing variable = NOT SHADOWED</h1>', rendered, rendered)
+
+    def test_nested_component_instances_have_unique_context_with_unfilled_slots_and_component_tag(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component name='parent_component' %}")
+        rendered = template.render(Context())
+
+        self.assertIn('<h1>Uniquely named variable = unique_val</h1>', rendered, rendered)
+        self.assertIn('<h1>Uniquely named variable = slot_default_unique</h1>', rendered, rendered)
+
+    def test_nested_component_context_shadows_parent_with_unfilled_slots_and_component_block_tag(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'parent_component' %}{% endcomponent_block %}")
+        rendered = template.render(Context())
+
+        self.assertIn('<h1>Shadowing variable = override</h1>', rendered, rendered)
+        self.assertIn('<h1>Shadowing variable = slot_default_override</h1>', rendered, rendered)
+        self.assertNotIn('<h1>Shadowing variable = NOT SHADOWED</h1>', rendered, rendered)
+
+    def test_nested_component_instances_have_unique_context_with_unfilled_slots_and_component_block_tag(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'parent_component' %}{% endcomponent_block %}")
+        rendered = template.render(Context())
+
+        self.assertIn('<h1>Uniquely named variable = unique_val</h1>', rendered, rendered)
+        self.assertIn('<h1>Uniquely named variable = slot_default_unique</h1>', rendered, rendered)
+
+    def test_nested_component_context_shadows_parent_with_filled_slots(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'parent_component' %}"
+                            "{% slot 'content' %}{% component name='variable_display' "
+                            "shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}{% endslot %}"
+                            "{% endcomponent_block %}")
+        rendered = template.render(Context())
+
+        self.assertIn('<h1>Shadowing variable = override</h1>', rendered, rendered)
+        self.assertIn('<h1>Shadowing variable = shadow_from_slot</h1>', rendered, rendered)
+        self.assertNotIn('<h1>Shadowing variable = NOT SHADOWED</h1>', rendered, rendered)
+
+    def test_nested_component_instances_have_unique_context_with_filled_slots(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'parent_component' %}"
+                            "{% slot 'content' %}{% component name='variable_display' "
+                            "shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}{% endslot %}"
+                            "{% endcomponent_block %}")
+        rendered = template.render(Context())
+
+        self.assertIn('<h1>Uniquely named variable = unique_val</h1>', rendered, rendered)
+        self.assertIn('<h1>Uniquely named variable = unique_from_slot</h1>', rendered, rendered)
+
+    def test_nested_component_context_shadows_outer_context_with_unfilled_slots_and_component_tag(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component name='parent_component' %}")
+        rendered = template.render(Context({'shadowing_variable': 'NOT SHADOWED'}))
+
+        self.assertIn('<h1>Shadowing variable = override</h1>', rendered, rendered)
+        self.assertIn('<h1>Shadowing variable = slot_default_override</h1>', rendered, rendered)
+        self.assertNotIn('<h1>Shadowing variable = NOT SHADOWED</h1>', rendered, rendered)
+
+    def test_nested_component_context_shadows_outer_context_with_unfilled_slots_and_component_block_tag(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'parent_component' %}{% endcomponent_block %}")
+        rendered = template.render(Context({'shadowing_variable': 'NOT SHADOWED'}))
+
+        self.assertIn('<h1>Shadowing variable = override</h1>', rendered, rendered)
+        self.assertIn('<h1>Shadowing variable = slot_default_override</h1>', rendered, rendered)
+        self.assertNotIn('<h1>Shadowing variable = NOT SHADOWED</h1>', rendered, rendered)
+
+    def test_nested_component_context_shadows_outer_context_with_filled_slots(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'parent_component' %}"
+                            "{% slot 'content' %}{% component name='variable_display' "
+                            "shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}{% endslot %}"
+                            "{% endcomponent_block %}")
+        rendered = template.render(Context({'shadowing_variable': 'NOT SHADOWED'}))
+
+        self.assertIn('<h1>Shadowing variable = override</h1>', rendered, rendered)
+        self.assertIn('<h1>Shadowing variable = shadow_from_slot</h1>', rendered, rendered)
+        self.assertNotIn('<h1>Shadowing variable = NOT SHADOWED</h1>', rendered, rendered)
+
+
+class ParentArgsTests(SimpleTestCase):
+    def test_parent_args_can_be_drawn_from_context(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'parent_with_args' parent_value=parent_value %}{%endcomponent_block %}")
+        rendered = template.render(Context({'parent_value': 'passed_in'}))
+
+        self.assertIn('<h1>Shadowing variable = passed_in</h1>', rendered, rendered)
+        self.assertIn('<h1>Uniquely named variable = passed_in</h1>', rendered, rendered)
+        self.assertNotIn('<h1>Shadowing variable = NOT SHADOWED</h1>', rendered, rendered)
+
+    def test_parent_args_available_outside_slots(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'parent_with_args' parent_value='passed_in' %}{%endcomponent_block %}")
+        rendered = template.render(Context())
+
+        self.assertIn('<h1>Shadowing variable = passed_in</h1>', rendered, rendered)
+        self.assertIn('<h1>Uniquely named variable = passed_in</h1>', rendered, rendered)
+        self.assertNotIn('<h1>Shadowing variable = NOT SHADOWED</h1>', rendered, rendered)
+
+    def test_parent_args_available_in_slots(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'parent_with_args' parent_value='passed_in' %}"
+                            "{% slot 'content' %}{% component name='variable_display' "
+                            "shadowing_variable='value_from_slot' new_variable=inner_parent_value %}{% endslot %}"
+                            "{%endcomponent_block %}")
+        rendered = template.render(Context())
+
+        self.assertIn('<h1>Shadowing variable = value_from_slot</h1>', rendered, rendered)
+        self.assertIn('<h1>Uniquely named variable = passed_in</h1>', rendered, rendered)
+        self.assertNotIn('<h1>Shadowing variable = NOT SHADOWED</h1>', rendered, rendered)
+
+
+class ContextCalledOnceTests(SimpleTestCase):
+    def test_one_context_call_with_simple_component(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component name='incrementer' %}")
+        rendered = template.render(Context()).strip()
+
+        self.assertEqual(rendered, '<p class="incrementer">value=1;calls=1</p>', rendered)
+
+    def test_one_context_call_with_simple_component_and_arg(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component name='incrementer' value='2' %}")
+        rendered = template.render(Context()).strip()
+
+        self.assertEqual(rendered, '<p class="incrementer">value=3;calls=1</p>', rendered)
+
+    def test_one_context_call_with_component_block(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'incrementer' %}{% endcomponent_block %}")
+        rendered = template.render(Context()).strip()
+
+        self.assertEqual(rendered, '<p class="incrementer">value=1;calls=1</p>', rendered)
+
+    def test_one_context_call_with_component_block_and_arg(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'incrementer' value='3' %}{% endcomponent_block %}")
+        rendered = template.render(Context()).strip()
+
+        self.assertEqual(rendered, '<p class="incrementer">value=4;calls=1</p>', rendered)
+
+    def test_one_context_call_with_slot(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'incrementer' %}{% slot 'content' %}"
+                            "<p>slot</p>{% endslot %}{% endcomponent_block %}")
+        rendered = template.render(Context()).strip()
+
+        self.assertEqual(rendered, '<p class="incrementer">value=1;calls=1</p>\n<p>slot</p>', rendered)
+
+    def test_one_context_call_with_slot_and_arg(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'incrementer' value='3' %}{% slot 'content' %}"
+                            "<p>slot</p>{% endslot %}{% endcomponent_block %}")
+        rendered = template.render(Context()).strip()
+
+        self.assertEqual(rendered, '<p class="incrementer">value=4;calls=1</p>\n<p>slot</p>', rendered)
+


### PR DESCRIPTION
Hey, sorry to drop a bunch of changes on you, but I encountered an issue, had to dig in deep to figure out what was going on, and then needed to change a bunch of stuff to fix my bug.  Here's an overview:

My original problem came when I tried to pass an object as a variable into a `component_block` tag, then have the context method process it into a handful of context variables.  Long story short, this wasn't working, because the context method sometimes gets called twice, with the outputs of the first call being the inputs of the second call.  That works fine if the context method doesn't transform its arguments, but fails when the context variables are different than the component params.

My fix was essentially just to have a single place for calling the context method (in the ComponentNode's render method), then to pass the context itself into the component's render method.  I think this is more straightforward and fixed my problem nicely.  As a side benefit, I think it will fix the CSRF problem in #12, at least when component_block is used.  Previously, the non-slot portions of the component were being rendered with a bare `Context`, not a `RequestContext`.  I reworked it so that the component renders itself with the context (presumably a RequestContext) that the template engine passes to it, so hopefully that will help.  I think using a component tag still won't work, because that tag doesn't get a context.  You could fix that by making it a `takes_context` tag, but I didn't make that change.

I also made some assorted tweaks as I was studying the code to help me follow better.  I left those in this PR, but you can obviously disregarded them if you don't think they're helpful.

I added a bunch of tests to look at various permutations of context, and everything passes.  That said, I can't swear that these changes won't break someone's code in some subtle way.

I hope these are helpful, and I'm happy to provide more explanation about anything I did.