### PR TITLE
Minor bugfix

### DIFF
--- a/django_components/component.py
+++ b/django_components/component.py
@@ -45,7 +45,7 @@ class Component(with_metaclass(MediaDefiningClass)):
         return NodeList(node for node in template.template.nodelist if is_slot_node(node))
 
     def render(self, context, slots_filled=None):
-        slots_filled = slots_filled or []
+        slots_filled = slots_filled or {}
         template = get_template(self.template(context))
         slots_in_template = self.slots_in_template(template)
 

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -148,11 +148,7 @@ class ComponentNode(Node):
 
         with context.update(extra_context):
             self.slots.render(context)
-            if COMPONENT_CONTEXT_KEY in context.render_context:
-                slots_filled = context.render_context[COMPONENT_CONTEXT_KEY][self.component]
-            else:
-                slots_filled = []
-
+            slots_filled = context.render_context.get(COMPONENT_CONTEXT_KEY, {}).get(self.component, {})
             return self.component.render(context, slots_filled=slots_filled)
 
 

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -331,10 +331,10 @@ class MultiComponentTests(SimpleTestCase):
                         + second_component_slot + '{% endcomponent_block %}')
 
     def expected_result(self, first_component_slot='', second_component_slot=''):
-        return (f'<custom-template><header>{first_component_slot or "Default header"}</header>'
-                '<main>Default main</main><footer>Default footer</footer></custom-template>'
-                f'<custom-template><header>{second_component_slot or "Default header"}</header>'
-                '<main>Default main</main><footer>Default footer</footer></custom-template>')
+        return ('<custom-template><header>{}</header>'.format(first_component_slot or "Default header")
+                + '<main>Default main</main><footer>Default footer</footer></custom-template>'
+                + '<custom-template><header>{}</header>'.format(second_component_slot or "Default header")
+                + '<main>Default main</main><footer>Default footer</footer></custom-template>')
 
     def wrap_with_slot_tags(self, s):
         return '{% slot "header" %}' + s + '{% endslot %}'

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -313,3 +313,56 @@ class SlottedTemplateRegressionTests(SimpleTestCase):
         rendered = template.render(Context({}))
         self.assertHTMLEqual(rendered,
                              "Provided variable: <strong>provided value</strong>\nDefault: <p>default text</p>")
+
+
+class MultiComponentTests(SimpleTestCase):
+    def setUp(self):
+        component.registry.clear()
+
+    def register_components(self):
+        component.registry.register('first_component', SlottedComponent)
+        component.registry.register('second_component', SlottedComponentWithContext)
+
+    def make_template(self, first_component_slot='', second_component_slot=''):
+        return Template('{% load component_tags %}'
+                        "{% component_block 'first_component' %}"
+                        + first_component_slot + '{% endcomponent_block %}'
+                        "{% component_block 'second_component' variable='xyz' %}"
+                        + second_component_slot + '{% endcomponent_block %}')
+
+    def expected_result(self, first_component_slot='', second_component_slot=''):
+        return (f'<custom-template><header>{first_component_slot or "Default header"}</header>'
+                '<main>Default main</main><footer>Default footer</footer></custom-template>'
+                f'<custom-template><header>{second_component_slot or "Default header"}</header>'
+                '<main>Default main</main><footer>Default footer</footer></custom-template>')
+
+    def wrap_with_slot_tags(self, s):
+        return '{% slot "header" %}' + s + '{% endslot %}'
+
+    def test_both_components_render_correctly_with_no_slots(self):
+        self.register_components()
+        rendered = self.make_template().render(Context({}))
+        self.assertHTMLEqual(rendered, self.expected_result())
+
+    def test_both_components_render_correctly_with_slots(self):
+        self.register_components()
+        first_slot_content = '<p>Slot #1</p>'
+        second_slot_content = '<div>Slot #2</div>'
+        first_slot = self.wrap_with_slot_tags(first_slot_content)
+        second_slot = self.wrap_with_slot_tags(second_slot_content)
+        rendered = self.make_template(first_slot, second_slot).render(Context({}))
+        self.assertHTMLEqual(rendered, self.expected_result(first_slot_content, second_slot_content))
+
+    def test_both_components_render_correctly_when_only_first_has_slots(self):
+        self.register_components()
+        first_slot_content = '<p>Slot #1</p>'
+        first_slot = self.wrap_with_slot_tags(first_slot_content)
+        rendered = self.make_template(first_slot).render(Context({}))
+        self.assertHTMLEqual(rendered, self.expected_result(first_slot_content))
+
+    def test_both_components_render_correctly_when_only_second_has_slots(self):
+        self.register_components()
+        second_slot_content = '<div>Slot #2</div>'
+        second_slot = self.wrap_with_slot_tags(second_slot_content)
+        rendered = self.make_template('', second_slot).render(Context({}))
+        self.assertHTMLEqual(rendered, self.expected_result('', second_slot_content))


### PR DESCRIPTION
One more minor bug that I ran across.  If you have two `component_block` tags in the same template, and the second doesn't have any slots, you get a key error--the first tag adds the COMPONENT_CONTEXT_KEY subdict to the context, but nothing ever adds the second component as a key to the subdict before the render method tries to look that key up.