### PR TITLE
Outer context modifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Finally, we use django-components to tie this together. We create a Component by
 ```python
 from django_components import component
 
-class Calendar(component.Component):
+
+class Calendar(component.BaseComponent):
     def context(self, date):
         return {
             "date": date,
@@ -109,6 +110,7 @@ class Calendar(component.Component):
     class Media:
         css = {'all': ['[your app]/components/calendar/calendar.css']}
         js = ['[your app]/components/calendar/calendar.js']
+
 
 component.registry.register(name="calendar", component=Calendar)
 ```
@@ -199,6 +201,8 @@ By default, components can access context variables from the parent template, ju
 ```
 
 NOTE: `{% csrf_token %}` tags need access to the top-level context, and they will not function properly if they are rendered in a component that is called with the `only` modifier.
+
+Components can also access the outer context in their context methods by accessing the property `outer_context`.
 
 # Running the tests
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ Since the header block is unspecified, it's taken from the base template. If you
 
 As you can see, component slots lets you write reusable containers, that you fill out when you use a component. This makes for highly reusable components, that can be used in different circumstances.
 
+# Component context
+
+By default, components can access context variables from the parent template, just like templates that are included with the `{% include %}` tag. Just like with `{% include %}`, if you don't want the component template to have access to the parent context, add `only` to the end of the `{% component %}` (or `{% component_block %}` tag):
+
+```htmldjango
+   {% component name="calendar" date="2015-06-19" only %}
+```
+
+NOTE: `{% csrf_token %}` tags need access to the top-level context, and they will not function properly if they are rendered in a component that is called with the `only` modifier.
+
 # Running the tests
 
 To quickly run the tests install the local dependencies by running

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Finally, we use django-components to tie this together. We create a Component by
 from django_components import component
 
 
-class Calendar(component.BaseComponent):
+class Calendar(component.Component):
     def context(self, date):
         return {
             "date": date,

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -24,9 +24,8 @@ except ImportError:
 
 
 class Component(with_metaclass(MediaDefiningClass)):
-    __cached_slot_nodes = None
 
-    def __init__(self, component_name):
+    def __init__(self, component_name='unnamed component'):
         self.__component_name = component_name
 
     def context(self):
@@ -55,7 +54,7 @@ class Component(with_metaclass(MediaDefiningClass)):
         return {node.name: node.nodelist for node in template.template.nodelist if is_slot_node(node)}
 
     def render(self, context, slots_filled=None):
-        slots_filled = dict(slots_filled) or {}
+        slots_filled = slots_filled or {}
 
         template = get_template(self.template(context))
         slots_in_template = self.slots_in_template(template)

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -60,8 +60,8 @@ class Component(with_metaclass(MediaDefiningClass)):
         template = get_template(self.template(context))
         slots_in_template = self.slots_in_template(template)
 
-        defined_slot_names = {slots_in_template.keys()}
-        filled_slot_names = {slots_filled.keys()}
+        defined_slot_names = set(slots_in_template.keys())
+        filled_slot_names = set(slots_filled.keys())
         unexpected_slots = filled_slot_names - defined_slot_names
         if unexpected_slots:
             if settings.DEBUG:

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -25,7 +25,7 @@ except ImportError:
 
 class Component(with_metaclass(MediaDefiningClass)):
 
-    def __init__(self, component_name='unnamed component'):
+    def __init__(self, component_name):
         self.__component_name = component_name
 
     def context(self):

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -46,7 +46,7 @@ def get_components_from_registry(registry):
 
     components = []
     for component_class in unique_component_classes:
-        components.append(component_class())
+        components.append(component_class(component_class.__name__))
 
     return components
 

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -42,11 +42,11 @@ COMPONENT_CONTEXT_KEY = "component_context"
 def get_components_from_registry(registry):
     """Returns a list unique components from the registry."""
 
-    unique_component_classes = set(registry.all().values())
+    unique_component_classes = set(registry.all().items())
 
     components = []
-    for component_class in unique_component_classes:
-        components.append(component_class())
+    for name, component_class in unique_component_classes:
+        components.append(component_class(name))
 
     return components
 
@@ -131,6 +131,8 @@ class ComponentNode(Node):
         return "<Component Node: %s. Contents: %r>" % (self.component, self.slots)
 
     def render(self, context):
+        self.component.outer_context = context.flatten()
+
         # Resolve FilterExpressions and Variables that were passed as args to the component, then call component's
         # context method to get values to insert into the context
         resolved_context_args = [safe_resolve(arg, context) for arg in self.context_args]

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -42,11 +42,11 @@ COMPONENT_CONTEXT_KEY = "component_context"
 def get_components_from_registry(registry):
     """Returns a list unique components from the registry."""
 
-    unique_component_classes = set(registry.all().items())
+    unique_component_classes = set(registry.all().values())
 
     components = []
-    for name, component_class in unique_component_classes:
-        components.append(component_class(name))
+    for component_class in unique_component_classes:
+        components.append(component_class())
 
     return components
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -14,7 +14,7 @@ class ComponentRegistryTest(SimpleTestCase):
             pass
 
         with self.assertRaises(NotImplementedError):
-            EmptyComponent().template({})
+            EmptyComponent("empty_component").template({})
 
     def test_simple_component(self):
         class SimpleComponent(component.Component):
@@ -30,7 +30,7 @@ class ComponentRegistryTest(SimpleTestCase):
                 css = {"all": ["style.css"]}
                 js = ["script.js"]
 
-        comp = SimpleComponent()
+        comp = SimpleComponent("simple_component")
         context = Context(comp.context(variable="test"))
 
         self.assertHTMLEqual(comp.render_dependencies(), dedent("""
@@ -48,7 +48,7 @@ class ComponentRegistryTest(SimpleTestCase):
                 css = {"all": ["style.css", "style2.css"]}
                 js = ["script.js", "script2.js"]
 
-        comp = MultistyleComponent()
+        comp = MultistyleComponent("multistyle_component")
 
         self.assertHTMLEqual(comp.render_dependencies(), dedent("""
             <link href="style.css" type="text/css" media="all" rel="stylesheet">
@@ -68,7 +68,7 @@ class ComponentRegistryTest(SimpleTestCase):
             def template(self, context):
                 return "filtered_template.html"
 
-        comp = FilteredComponent()
+        comp = FilteredComponent("filtered_component")
         context = Context(comp.context(var1="test1", var2="test2"))
 
         self.assertHTMLEqual(comp.render(context), dedent("""

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -67,11 +67,20 @@ class IncrementerComponent(component.Component):
         return "incrementer.html"
 
 
+class OuterContextComponent(component.Component):
+    def context(self):
+        return self.outer_context
+
+    def template(self, context):
+        return "simple_template.html"
+
+
 component.registry.register(name='parent_component', component=ParentComponent)
 component.registry.register(name='parent_with_args', component=ParentComponentWithArgs)
 component.registry.register(name='variable_display', component=VariableDisplay)
 component.registry.register(name='incrementer', component=IncrementerComponent)
 component.registry.register(name='simple_component', component=SimpleComponent)
+component.registry.register(name='outer_context_component', component=OuterContextComponent)
 
 
 class ContextTests(SimpleTestCase):
@@ -262,3 +271,17 @@ class IsolatedContextTests(SimpleTestCase):
                             "{% component 'simple_component' only %}")
         rendered = template.render(Context({'variable': 'outer_value'})).strip()
         self.assertNotIn('outer_value', rendered, rendered)
+
+
+class OuterContextPropertyTests(SimpleTestCase):
+    def test_outer_context_property_with_component(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component 'outer_context_component' only %}")
+        rendered = template.render(Context({'variable': 'outer_value'})).strip()
+        self.assertIn('outer_value', rendered, rendered)
+
+    def test_outer_context_property_with_component_block(self):
+        template = Template("{% load component_tags %}{% component_dependencies %}"
+                            "{% component_block 'outer_context_component' only %}{% endcomponent_block %}")
+        rendered = template.render(Context({'variable': 'outer_value'})).strip()
+        self.assertIn('outer_value', rendered, rendered)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,6 +6,7 @@ from django_components import component
 class MockComponent(object):
     pass
 
+
 class ComponentRegistryTest(unittest.TestCase):
     def setUp(self):
         self.registry = component.ComponentRegistry()


### PR DESCRIPTION
Hi Emil,

I've been getting a ton of use out of this library and have come up with a few suggestions based on the rough patches that I've encountered.  This PR is focused on giving users more control over how the component can access the outer context, and also adding flexibility in how arguments are passed to the component.  I have a couple other ideas that aren't quite camera-ready... I'll mention them at the end of this.

This is a pretty large block of changes, so here's what's going on in detail:
* Both `component_block` and `component` now allow the user to decide whether or not the component should be able to access the outer context.  The syntax is modelled on the syntax for the [include tag in base Django](https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#include): by default, the outer context is passed, but you can append `only` to the end of the token to screen the component from the outer context.
* Both tags can now parse any combination of positional/keyword args and pass them to the context method.
* As a convenience, users now have access to an outer_context property in the Component context() method, which you can use to derive info from the outer context without having to pass the specific values in to the tag.
* To make things a little easier to work with, I made some significant changes to how slots are handled.  Previously, each slot rendered itself and included itself in the context, then the component pull the rendered strings out.  As I revised it, the slots no longer use their render methods.  Instead, the component just builds a single nodelist out of its slots and the rest of the template and renders it in one go.  Apart from (hopefully) simplifying the code, the main impact is that you can now have multiple instances of the same slot name in a block, and the component will just append all of the blocks into the template slot.

The other two ideas I wanted to get your thoughts on are both in branches on my fork, but not yet very well tested or documented:
* Declarative syntax for creating components ([here](https://github.com/rbeard0330/django-components/tree/new_subclass)).  The idea here was to remove some of the boilerplate in making new components.  Essentially, you subclass the new version of Component, assigning a name for the component, a template, and the component props as class variables.  Then there's an __init_subclass__ method that sanity-checks the component values and registers the component.  There's also an overrideable context method that assembles all the arguments and puts them in the context.  This should be fully backwards-compatible.
* This is a bit silly, but it would be nice to be able to pass several args to a component without having insanely long lines.  A potential fix ([here](https://github.com/rbeard0330/django-components/tree/extra_args)) is to have another tag (I called it component args) that the parser can harvest arguments from.  Not sure it's worth complicating the syntax for such a marginal benefit, but that's your call.

As always, happy to discuss/modify/whatever as you think best.

Cheers,
Robert