### PR TITLE
Fixing bug in last PR

### DIFF
--- a/django_components/component.py
+++ b/django_components/component.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import warnings
 from itertools import chain
 
@@ -76,9 +77,11 @@ class Component(with_metaclass(MediaDefiningClass)):
         # Replace slot nodes with their nodelists, then combine into a single, flat nodelist
         node_iterator = ([node] if not is_slot_node(node) else combined_slots[node.name]
                          for node in template.template.nodelist)
-        flattened_nodelist = NodeList(chain.from_iterable(node_iterator))
 
-        return flattened_nodelist.render(context)
+        cloned_template = deepcopy(template)
+        cloned_template.template.nodelist = NodeList(chain.from_iterable(node_iterator))
+
+        return cloned_template.template.render(context)
 
     class Media:
         css = {}

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -25,7 +25,7 @@ except ImportError:
 
 class Component(with_metaclass(MediaDefiningClass)):
 
-    def __init__(self, component_name):
+    def __init__(self, component_name='unnamed component'):
         self.__component_name = component_name
 
     def context(self):

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy
 import warnings
 from itertools import chain
 
@@ -74,14 +74,17 @@ class Component(with_metaclass(MediaDefiningClass)):
                 del slots_filled[unexpected_slot]
 
         combined_slots = dict(slots_in_template, **slots_filled)
-        # Replace slot nodes with their nodelists, then combine into a single, flat nodelist
-        node_iterator = ([node] if not is_slot_node(node) else combined_slots[node.name]
-                         for node in template.template.nodelist)
+        if combined_slots:
+            # Replace slot nodes with their nodelists, then combine into a single, flat nodelist
+            node_iterator = ([node] if not is_slot_node(node) else combined_slots[node.name]
+                             for node in template.template.nodelist)
 
-        cloned_inner_template = deepcopy(template.template)
-        cloned_inner_template.nodelist = NodeList(chain.from_iterable(node_iterator))
+            template = copy(template.template)
+            template.nodelist = NodeList(chain.from_iterable(node_iterator))
+        else:
+            template = template.template
 
-        return cloned_inner_template.render(context)
+        return template.render(context)
 
     class Media:
         css = {}

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -1,5 +1,5 @@
-from copy import copy
 import warnings
+from copy import copy
 from itertools import chain
 
 from django.conf import settings

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -78,10 +78,10 @@ class Component(with_metaclass(MediaDefiningClass)):
         node_iterator = ([node] if not is_slot_node(node) else combined_slots[node.name]
                          for node in template.template.nodelist)
 
-        cloned_template = deepcopy(template)
-        cloned_template.template.nodelist = NodeList(chain.from_iterable(node_iterator))
+        cloned_inner_template = deepcopy(template.template)
+        cloned_inner_template.nodelist = NodeList(chain.from_iterable(node_iterator))
 
-        return cloned_template.template.render(context)
+        return cloned_inner_template.render(context)
 
     class Media:
         css = {}

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -25,7 +25,7 @@ except ImportError:
 
 class Component(with_metaclass(MediaDefiningClass)):
 
-    def __init__(self, component_name='unnamed component'):
+    def __init__(self, component_name):
         self.__component_name = component_name
 
     def context(self):


### PR DESCRIPTION
I'm embarrassed to report that my last PR interferes with Django's test instrumentation.  Specifically, if you try to use the `assertTemplateUsed` test assertion for `{% component %}`-rendered templates, it will fail (and the `assertTemplateNotUsed` assertion could pass erroneously).  I don't think this was ever working 100% right for `{% component_block %}`, but moving regular component renders from being a simple tag to using the `Component.render()` method has made them also not work properly.

The root cause is that the TemplateUsed/NotUsed assertions are driven by calls to `Template.render()` (which is a wrapper around `Template._render()`.  For `TestCase` (but not `SimpleTestCase`), Django monkey-patches `Template._render()` to emit a signal every time that method is called, which the test framework tracks.  For slotted components, `Component.render()` has always just built a nodelist and rendered it directly rather than going through a template, so those calls haven't been made.  My last couple rounds of changes have been pushing more and more components through that rendering path.

I think the fix is not too difficult.  The only problem with using `Template.render()` for slotted components is that the template has the wrong nodelist.  We can't directly modify the template's nodelist, since Django caches them, but we can do a shallow copy of the template, drop in the new nodelist, and render the copied component.  (I don't think a deepcopy is necessary, and it's also extraordinarily expensive, as each template has a reference to the entire template engine.)

Most of this PR is setting up some basic regression tests.  Django doesn't set up the TemplateUsed machinery for a `SimpleTestCase`, so I did (a very rudimentary version of) the setup for the test.  The alternative would be to create a dummy project so that the tests could run in a real `TestCase`.