### PR TITLE
Change time for compilation of component nodelist

### DIFF
--- a/benchmarks/component_rendering.py
+++ b/benchmarks/component_rendering.py
@@ -1,14 +1,11 @@
-try:
-    from time import perf_counter
-except ImportError:
-    perf_counter = lambda: 0  # NOQA
+from time import perf_counter
 
 from django.template import Context, Template
 
 from django_components import component
 
-from .django_test_setup import *  # NOQA
-from .testutils import Django111CompatibleSimpleTestCase as SimpleTestCase
+from tests.django_test_setup import *  # NOQA
+from tests.testutils import Django111CompatibleSimpleTestCase as SimpleTestCase
 
 
 class SlottedComponent(component.Component):
@@ -41,6 +38,5 @@ class RenderBenchmarks(SimpleTestCase):
         for _ in range(1000):
             template.render(Context({}))
         end_time = perf_counter()
-        _total_elapsed = end_time - start_time  # NOQA
-        # Only runs in Python 3
-        # print(f'{total_elapsed } ms per template')
+        total_elapsed = end_time - start_time  # NOQA
+        print(f'{total_elapsed } ms per template')

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -86,7 +86,7 @@ class Component(with_metaclass(MediaDefiningClass)):
         else:
             self.instance_template = component_template.template
 
-    def render(self, context, slots_filled=None):
+    def render(self, context):
         return self.instance_template.render(context)
 
     class Media:

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -26,7 +26,7 @@ except ImportError:
 
 class Component(with_metaclass(MediaDefiningClass)):
 
-    def __init__(self, component_name='unnamed component'):
+    def __init__(self, component_name):
         self.__component_name = component_name
 
     def context(self):

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -26,7 +26,7 @@ except ImportError:
 
 class Component(with_metaclass(MediaDefiningClass)):
 
-    def __init__(self, component_name):
+    def __init__(self, component_name='unnamed component'):
         self.__component_name = component_name
 
     def context(self):

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -126,6 +126,7 @@ class ComponentNode(Node):
         self.context_args = context_args or []
         self.context_kwargs = context_kwargs or {}
         self.component, self.isolated_context = component, isolated_context
+        self.component.compile_instance_template(self.slots)
 
     def __repr__(self):
         return "<Component Node: %s. Contents: %r>" % (self.component, self.slots)

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -124,8 +124,9 @@ class ComponentNode(Node):
         self.context_kwargs = context_kwargs or {}
         self.component, self.isolated_context = component, isolated_context
         slot_dict = defaultdict(NodeList)
-        for slot in slots or []:
-            slot_dict[slot.name].extend(slot.nodelist)
+        if slots:
+            for slot in slots:
+                slot_dict[slot.name].extend(slot.nodelist)
         self.component.compile_instance_template(slot_dict)
 
     def __repr__(self):

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -120,16 +120,16 @@ def do_slot(parser, token, component=None):
 
 class ComponentNode(Node):
     def __init__(self, component, context_args, context_kwargs, slots=None, isolated_context=False):
-        self.slots = defaultdict(NodeList)
-        for slot in slots or []:
-            self.slots[slot.name].extend(slot.nodelist)
         self.context_args = context_args or []
         self.context_kwargs = context_kwargs or {}
         self.component, self.isolated_context = component, isolated_context
-        self.component.compile_instance_template(self.slots)
+        slot_dict = defaultdict(NodeList)
+        for slot in slots or []:
+            slot_dict[slot.name].extend(slot.nodelist)
+        self.component.compile_instance_template(slot_dict)
 
     def __repr__(self):
-        return "<Component Node: %s. Contents: %r>" % (self.component, self.slots)
+        return "<Component Node: %s. Contents: %r>" % (self.component, self.component.instance_template.nodelist)
 
     def render(self, context):
         self.component.outer_context = context.flatten()
@@ -147,7 +147,7 @@ class ComponentNode(Node):
             context = context.new()
 
         with context.update(component_context):
-            return self.component.render(context, slots_filled=self.slots)
+            return self.component.render(context)
 
 
 @register.tag("component_block")

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -32,6 +32,7 @@ class ComponentRegistryTest(SimpleTestCase):
 
         comp = SimpleComponent("simple_component")
         context = Context(comp.context(variable="test"))
+        comp.compile_instance_template({})
 
         self.assertHTMLEqual(comp.render_dependencies(), dedent("""
             <link href="style.css" type="text/css" media="all" rel="stylesheet">
@@ -70,6 +71,7 @@ class ComponentRegistryTest(SimpleTestCase):
 
         comp = FilteredComponent("filtered_component")
         context = Context(comp.context(var1="test1", var2="test2"))
+        comp.compile_instance_template({})
 
         self.assertHTMLEqual(comp.render(context), dedent("""
             Var1: <strong>test1</strong>

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,42 @@
+from time import perf_counter
+
+from django.template import Context, Template
+
+from django_components import component
+
+from .django_test_setup import *  # NOQA
+from .testutils import Django111CompatibleSimpleTestCase as SimpleTestCase
+
+
+class SlottedComponent(component.Component):
+    def template(self, context):
+        return "slotted_template.html"
+
+
+class SimpleComponent(component.Component):
+    def context(self, variable, variable2="default"):
+        return {
+            "variable": variable,
+            "variable2": variable2,
+        }
+
+    def template(self, context):
+        return "simple_template.html"
+
+
+class RenderBenchmarks(SimpleTestCase):
+    def setUp(self):
+        component.registry.clear()
+        component.registry.register('test_component', SlottedComponent)
+        component.registry.register('inner_component', SimpleComponent)
+
+    def test_render_time(self):
+        template = Template("{% load component_tags %}{% component_block 'test_component' %}"
+                            "{% slot \"header\" %}{% component 'inner_component' variable='foo' %}{% endslot %}"
+                            "{% endcomponent_block %}", name='root')
+        start_time = perf_counter()
+        for _ in range(1000):
+            template.render(Context({}))
+        end_time = perf_counter()
+        total_elapsed = end_time - start_time
+        print(f'{total_elapsed } ms per template')

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,7 +1,7 @@
 try:
     from time import perf_counter
 except ImportError:
-    perf_counter = lambda: 0
+    perf_counter = lambda: 0  # NOQA
 
 from django.template import Context, Template
 
@@ -41,6 +41,6 @@ class RenderBenchmarks(SimpleTestCase):
         for _ in range(1000):
             template.render(Context({}))
         end_time = perf_counter()
-        _total_elapsed = end_time - start_time
+        _total_elapsed = end_time - start_time  # NOQA
         # Only runs in Python 3
         # print(f'{total_elapsed } ms per template')

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,4 +1,7 @@
-from time import perf_counter
+try:
+    from time import perf_counter
+except ImportError:
+    perf_counter = lambda: 0
 
 from django.template import Context, Template
 
@@ -38,5 +41,6 @@ class RenderBenchmarks(SimpleTestCase):
         for _ in range(1000):
             template.render(Context({}))
         end_time = perf_counter()
-        total_elapsed = end_time - start_time
-        print(f'{total_elapsed } ms per template')
+        _total_elapsed = end_time - start_time
+        # Only runs in Python 3
+        # print(f'{total_elapsed } ms per template')


### PR DESCRIPTION
Hi Emil,

This one is mostly a performance tweak.  In the current version, a new nodelist gets built from the template every time `Component.render()` is called.  However, nothing in the nodelist should change from render to render in terms of the nodes that are built from the component template and any slots that are passed.*  That suggests that you can save some cycles by moving the nodelist compilation out of the render cycle and into the template compilation phase.  That's what I've done here.

* Strictly speaking, this is not true if the template is being dynamically selected based on the context.  If that's an important use-case to keep supporting, then this won't work.

I added a very simplistic "benchmark" that just renders a template a bunch of times.  It showed about a 50% speedup on my system.

Let me know what you think.

Best,
Robert