### PR TITLE
Class decorator and test

### DIFF
--- a/django_components/component.py
+++ b/django_components/component.py
@@ -97,3 +97,20 @@ def is_slot_node(node):
 
 # This variable represents the global component registry
 registry = ComponentRegistry()
+
+def register(name):
+    """Class decorator to register a component.
+
+
+    Usage:
+
+    @register("my_component")
+    class MyComponent(component.Component):
+        ...
+
+    """
+    def decorator(component):
+        registry.register(name=name, component=component)
+        return component
+
+    return decorator

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -9,6 +9,14 @@ from .testutils import Django111CompatibleSimpleTestCase as SimpleTestCase
 
 
 class ComponentRegistryTest(SimpleTestCase):
+
+    def test_register_class_decorator(self):
+        @component.register("decorated_component")
+        class TestComponent(component.Component):
+            pass
+
+        self.assertEqual(component.registry.get("decorated_component"), TestComponent)
+
     def test_empty_component(self):
         class EmptyComponent(component.Component):
             pass


### PR DESCRIPTION
This adds a simple class decorator to fix https://github.com/EmilStenstrom/django-components/issues/31. Basically this:

```
from django_components import component

@component.register("my-component")
class MyComponent(component.Component):
    ...
```
