### PR TITLE
Rework slot management to avoid nodelist copying

### DIFF
--- a/django_components/component.py
+++ b/django_components/component.py
@@ -1,10 +1,9 @@
 import warnings
-from copy import copy, deepcopy
 from functools import lru_cache
 
 from django.conf import settings
 from django.forms.widgets import MediaDefiningClass
-from django.template.base import Node, NodeList, TokenType
+from django.template.base import Node, TokenType
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
 
@@ -12,6 +11,7 @@ from django.utils.safestring import mark_safe
 from django_components.component_registry import AlreadyRegistered, ComponentRegistry, NotRegistered  # noqa
 
 TEMPLATE_CACHE_SIZE = getattr(settings, "COMPONENTS", {}).get('TEMPLATE_CACHE_SIZE', 128)
+ACTIVE_SLOT_CONTEXT_KEY = '_DJANGO_COMPONENTS_ACTIVE_SLOTS'
 
 
 class SimplifiedInterfaceMediaDefiningClass(MediaDefiningClass):
@@ -80,18 +80,11 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
 
     @lru_cache(maxsize=TEMPLATE_CACHE_SIZE)
     def get_processed_template(self, template_name):
-        """Retrieve the requested template and add a link to this component to each SlotNode in the template."""
+        """Retrieve the requested template and check for unused slots."""
 
-        source_template = get_template(template_name)
+        component_template = get_template(template_name).template
 
-        # The template may be shared with another component (e.g., due to caching). To ensure that each
-        # SlotNode is unique between components, we have to copy the nodes in the template nodelist and
-        # any contained nodelists.
-        component_template = copy(source_template.template)
-        cloned_nodelist = [duplicate_node(node) for node in component_template.nodelist]
-        component_template.nodelist = NodeList(cloned_nodelist)
-
-        # Traverse template nodes and descendants, and give each slot node a reference to this component.
+        # Traverse template nodes and descendants
         visited_nodes = set()
         nodes_to_visit = list(component_template.nodelist)
         slots_seen = set()
@@ -104,7 +97,6 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
                 nodes_to_visit.extend(getattr(current_node, nodelist_name, []))
             if self.is_slot_node(current_node):
                 slots_seen.add(current_node.name)
-                current_node.parent_component = self
 
         # Check and warn for unknown slots
         if settings.DEBUG:
@@ -122,7 +114,9 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
     def render(self, context):
         template_name = self.template(context)
         instance_template = self.get_processed_template(template_name)
-        return instance_template.render(context)
+        active_slots = {**context.get(ACTIVE_SLOT_CONTEXT_KEY, {}), **self.slots}
+        with context.update({ACTIVE_SLOT_CONTEXT_KEY: active_slots}):
+            return instance_template.render(context)
 
     class Media:
         css = {}
@@ -131,24 +125,6 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
 
 # This variable represents the global component registry
 registry = ComponentRegistry()
-
-
-def duplicate_node(source_node):
-    """Perform a shallow copy of source_node and then recursively copy over each of source_node's nodelists.
-
-    If a nodelist is a dynamic property that cannot be set, fall back to a deepcopy of source_node."""
-
-    try:
-        clone = copy(source_node)
-        for nodelist_name in source_node.child_nodelists:
-            nodelist = getattr(source_node, nodelist_name, NodeList())
-            nodelist_contents = [duplicate_node(n) for n in nodelist]
-            setattr(clone, nodelist_name, type(nodelist)(nodelist_contents))
-        return clone
-    except AttributeError:
-        # AttributeError is raised if an attribute cannot be set (e.g., IfNode's nodelist,
-        # which is a read-only property).
-        return deepcopy(source_node)
 
 
 def register(name):

--- a/tests/templates/template_with_illegal_slot.html
+++ b/tests/templates/template_with_illegal_slot.html
@@ -1,0 +1,2 @@
+{% load component_tags %}
+{% include 'slotted_template.html' with context=None only%}

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -2,9 +2,9 @@ from textwrap import dedent
 
 from django.template import Context, Template, TemplateSyntaxError
 
-from .django_test_setup import *  # NOQA
 from django_components import component
 
+from .django_test_setup import *  # NOQA
 from .testutils import Django30CompatibleSimpleTestCase as SimpleTestCase
 
 
@@ -31,6 +31,11 @@ class IffedComponent(SimpleComponent):
 class SlottedComponent(component.Component):
     def template(self, context):
         return "slotted_template.html"
+
+
+class BrokenComponent(component.Component):
+    def template(self, context):
+        return "template_with_illegal_slot.html"
 
 
 class SlottedComponentWithMissingVariable(component.Component):
@@ -589,6 +594,7 @@ class TemplateSyntaxErrorTests(SimpleTestCase):
     def setUpClass(cls):
         super().setUpClass()
         component.registry.register('test', SlottedComponent)
+        component.registry.register('broken_component', BrokenComponent)
 
     def test_variable_outside_slot_tag_is_error(self):
         with self.assertRaises(TemplateSyntaxError):
@@ -633,4 +639,68 @@ class TemplateSyntaxErrorTests(SimpleTestCase):
                 {% component_block "test" %}
                     {% slot "header" %}{% endslot %}
             """
+            )
+
+    def test_slot_with_no_parent_is_error_in_debug(self):
+        with self.settings(DEBUG=True):
+            with self.assertRaises(TemplateSyntaxError):
+                Template(
+                    """
+                    {% load component_tags %}
+                    {% slot "header" %}contents{% endslot %}
+                """
+                ).render(Context({}))
+
+    def test_slot_with_no_parent_returns_contents_in_production(self):
+        with self.settings(DEBUG=False):
+            template = Template(
+                """
+                {% load component_tags %}
+                    {% slot "header" %}<p>contents</p>{% endslot %}
+            """
+            )
+            rendered = template.render(Context({}))
+
+            self.assertHTMLEqual(
+                rendered,
+                """<p>contents</p>""",
+            )
+
+    def test_isolated_slot_is_error_in_debug(self):
+        with self.settings(DEBUG=True):
+            with self.assertRaises(TemplateSyntaxError):
+                Template(
+                    """
+                    {% load component_tags %}
+                    {% component_block "broken_component" %}
+                        {% slot "header" %}Custom header{% endslot %}
+                        {% slot "main" %}Custom main{% endslot %}
+                        {% slot "footer" %}Custom footer{% endslot %}
+                    {% endcomponent_block %}
+                """
+                ).render(Context({}))
+
+    def test_isolated_slot_returns_default_contents_in_production(self):
+        with self.settings(DEBUG=False):
+            template = Template(
+                """
+                {% load component_tags %}
+                {% component_block "broken_component" %}
+                    {% slot "header" %}Custom header{% endslot %}
+                    {% slot "main" %}Custom main{% endslot %}
+                    {% slot "footer" %}Custom footer{% endslot %}
+                {% endcomponent_block %}
+            """
+            )
+            rendered = template.render(Context({}))
+
+            self.assertHTMLEqual(
+                rendered,
+                """
+                <custom-template>
+                    <header>Default header</header>
+                    <main>Default main</main>
+                    <footer>Default footer</footer>
+                </custom-template>
+            """,
             )


### PR DESCRIPTION
See attached for some revisions that hopefully fix #64.

The general approach is for each component to add a context variable that is a dict with the names of the slots that have been provided to it and the relevant nodelists.  When each slot is rendered, it checks for its name in the dict, and renders either the override or the default nodelist.

If the dict isn't in the context, it means that the slot is either being rendered outside of a component or without access to the context provided by the component.  The current approach is to call this a TemplateSyntaxError in debug mode and to just render the slot's contents in production.  Alternatively, you could introspect your way up the call stack looking for the component that's making the render call, but that seems too weird to be a good idea.  I left that code in here in inactive form so you can see it, but I think it's probably best to just drop it.