### PR TITLE
Move duplicated isort config from setup.cfg to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,5 @@ exclude = '''
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+include_trailing_comma = "True"
+known_first_party = "django_components"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,3 @@
 [flake8]
 ignore = E302,W503
 max-line-length = 119
-
-[isort]
-line_length = 119
-multi_line_output = 5
-include_trailing_comma = True
-known_first_party =
-	django_components


### PR DESCRIPTION
There were duplicated config for isort in two files, this PR merge them into pyproject.toml
