### PR TITLE
Add `{% fill %}` tag as described in #133 

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,16 +323,21 @@ This makes it possible to organize your front-end around reusable components. In
 
 # Using slots in templates
 
-_New in version 0.26_ (__breaking change__): Defining slots and passing content to them used to be achieved by a single block tag `{% slot %}`. To make component nesting easier these functions have been split across two separate tags. Now, `{% slot %}` serves only to declare/define/open new slots inside the component template. The function of passing in content to a slot has been moved to a newly introduced `{% fill %}` tag.
+_New in version 0.26_:
 
-Components support something called 'slots'.
+- The `slot` tag now serves only to declare new slots inside the component template.
+  - To override the content of a declared slot, use the newly introduced `fill` tag instead.
+- Whereas unfilled slots used to raise a warning, filling a slot is now optional by default.
+  - To indicate that a slot must be filled, the new keyword `required` should be added at the end of the `slot` tag.  
+
+Components support something called 'slots'. 
 When a component is used inside another template, slots allow the parent template to override specific parts of the child component by passing in different content.
 This mechanism makes components more reusable and composable.
 
 In the example below we introduce two block tags that work hand in hand to make this work. These are...
 
-- `{% slot <name> %}`/`{% endslot %}`: Declare new slot on component template.
-- `{% fill <name> %}`/`{% endfill %}`: Used inside component block. The content of this block is injected into the slot with the same name.
+- `{% slot <name> %}`/`{% endslot %}`: Declares a new slot in the component template.
+- `{% fill <name> %}`/`{% endfill %}`: (Used inside a component block.) Fills a declared slot with the specified content.
 
 Let's update our calendar component to support more customization by updating our calendar.html template.
 

--- a/django_components/__init__.py
+++ b/django_components/__init__.py
@@ -1,7 +1,7 @@
 import glob
 import importlib
+import importlib.util
 import sys
-from importlib import import_module
 from pathlib import Path
 
 import django
@@ -15,7 +15,7 @@ if django.VERSION < (3, 2):
 
 
 def autodiscover():
-    from . import app_settings
+    from django_components.app_settings import app_settings
 
     if app_settings.AUTODISCOVER:
         # Autodetect a components.py file in each app directory
@@ -30,7 +30,7 @@ def autodiscover():
                 import_file(path)
 
     for path in app_settings.LIBRARIES:
-        import_module(path)
+        importlib.import_module(path)
 
 
 def import_file(path):

--- a/django_components/app_settings.py
+++ b/django_components/app_settings.py
@@ -1,5 +1,3 @@
-import sys
-
 from django.conf import settings
 
 
@@ -19,7 +17,11 @@ class AppSettings:
     def TEMPLATE_CACHE_SIZE(self):
         return self.settings.setdefault("template_cache_size", 128)
 
+    @property
+    def STRICT_SLOTS(self):
+        """If True, component slots that are declared must be explicitly filled; else
+        a TemplateSyntaxError is raised."""
+        return self.settings.setdefault("strict_slots", False)
+
 
 app_settings = AppSettings()
-app_settings.__name__ = __name__
-sys.modules[__name__] = app_settings

--- a/django_components/app_settings.py
+++ b/django_components/app_settings.py
@@ -17,11 +17,5 @@ class AppSettings:
     def TEMPLATE_CACHE_SIZE(self):
         return self.settings.setdefault("template_cache_size", 128)
 
-    @property
-    def STRICT_SLOTS(self):
-        """If True, component slots that are declared must be explicitly filled; else
-        a TemplateSyntaxError is raised."""
-        return self.settings.setdefault("strict_slots", False)
-
 
 app_settings = AppSettings()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ exclude = '''
 
 [tool.isort]
 profile = "black"
+line_length = 79
 multi_line_output = 3
 include_trailing_comma = "True"
 known_first_party = "django_components"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,11 @@
 [flake8]
 ignore = E302,W503
 max-line-length = 119
+exclude =
+    migrations
+    __pycache__
+    manage.py
+    settings.py
+    env
+    .env
+    .tox

--- a/tests/django_test_setup.py
+++ b/tests/django_test_setup.py
@@ -10,11 +10,12 @@ if not settings.configured:
                 "DIRS": ["tests/templates/"],
             }
         ],
-        COMPONENTS={"TEMPLATE_CACHE_SIZE": 128},
+        COMPONENTS={"template_cache_size": 128, "strict_slots": False},
         MIDDLEWARE=[
             "django_components.middleware.ComponentDependencyMiddleware"
         ],
         DATABASES={},
+        # DEBUG=True
     )
 
     django.setup()

--- a/tests/django_test_setup.py
+++ b/tests/django_test_setup.py
@@ -10,12 +10,11 @@ if not settings.configured:
                 "DIRS": ["tests/templates/"],
             }
         ],
-        COMPONENTS={"template_cache_size": 128, "strict_slots": False},
+        COMPONENTS={"template_cache_size": 128},
         MIDDLEWARE=[
             "django_components.middleware.ComponentDependencyMiddleware"
         ],
         DATABASES={},
-        # DEBUG=True
     )
 
     django.setup()

--- a/tests/templates/slotted_component_nesting_template_pt1_calendar.html
+++ b/tests/templates/slotted_component_nesting_template_pt1_calendar.html
@@ -1,0 +1,11 @@
+{% load component_tags %}
+<div class="calendar-component">
+  <h1>
+    {% slot "header" %}Today's date is <span>{{ date }}</span>{% endslot %}
+  </h1>
+  <main>
+  {% slot "body" %}
+    You have no events today.
+  {% endslot %}
+  </main>
+</div>

--- a/tests/templates/slotted_component_nesting_template_pt2_dashboard.html
+++ b/tests/templates/slotted_component_nesting_template_pt2_dashboard.html
@@ -1,0 +1,13 @@
+{% load component_tags %}
+<div class="dashboard-component">
+  {% component_block "calendar" date="2020-06-06" %}
+    {% fill "header" %}  {# fills and slots with same name relate to diff. things. #}
+      {% slot "header" %}Welcome to your dashboard!{% endslot %}
+    {% endfill %}
+    {% fill "body" %}Here are your to-do items for today:{% endfill %}
+  {% endcomponent_block %}
+  <ol>
+    {% for item in items %}
+      <li>{{ item }}</li>{% endfor %}
+  </ol>
+</div>

--- a/tests/templates/slotted_component_nesting_template_pt2_dashboard.html
+++ b/tests/templates/slotted_component_nesting_template_pt2_dashboard.html
@@ -8,6 +8,7 @@
   {% endcomponent_block %}
   <ol>
     {% for item in items %}
-      <li>{{ item }}</li>{% endfor %}
+      <li>{{ item }}</li>
+    {% endfor %}
   </ol>
 </div>

--- a/tests/templates/slotted_template.html
+++ b/tests/templates/slotted_template.html
@@ -1,6 +1,6 @@
 {% load component_tags %}
 <custom-template>
-    <header>{% slot header %}Default header{% endslot %}</header>
-    <main>{% slot main %}Default main{% endslot %}</main>
-    <footer>{% slot footer %}Default footer{% endslot %}</footer>
+    <header>{% slot "header" %}Default header{% endslot %}</header>
+    <main>{% slot "main" %}Default main{% endslot %}</main>
+    <footer>{% slot "footer" %}Default footer{% endslot %}</footer>
 </custom-template>

--- a/tests/templates/slotted_template_with_missing_variable.html
+++ b/tests/templates/slotted_template_with_missing_variable.html
@@ -1,7 +1,7 @@
 {% load component_tags %}
 <custom-template>
     {{ missing_context_variable }}
-    <header>{% slot header %}Default header{% endslot %}</header>
-    <main>{% slot main %}Default main{% endslot %}</main>
-    <footer>{% slot footer %}Default footer{% endslot %}</footer>
+    <header>{% slot "header" %}Default header{% endslot %}</header>
+    <main>{% slot "main" %}Default main{% endslot %}</main>
+    <footer>{% slot "footer" %}Default footer{% endslot %}</footer>
 </custom-template>

--- a/tests/templates/slotted_template_with_required_slot.html
+++ b/tests/templates/slotted_template_with_required_slot.html
@@ -1,0 +1,5 @@
+{% load component_tags %}
+<div class="header-box">
+  <h1>{% slot "title" required %}{% endslot %}</h1>
+  <h2>{% slot "subtitle" %}{% endslot %}</h2>
+</div>

--- a/tests/templates/template_with_conditional_slots.html
+++ b/tests/templates/template_with_conditional_slots.html
@@ -1,0 +1,8 @@
+{# Example from django-components/issues/98 #}
+{% load component_tags %}
+<div class="frontmatter-component">
+    <div class="title">{% slot "title" %}Title{% endslot %}</div>
+    {% if_filled "subtitle" %}
+        <div class="subtitle">{% slot "subtitle" %}Optional subtitle{% endslot %}</div>
+    {% endif_filled %}
+</div>

--- a/tests/templates/template_with_if_elif_else_conditional_slots.html
+++ b/tests/templates/template_with_if_elif_else_conditional_slots.html
@@ -1,0 +1,12 @@
+{# Example from django-components/issues/98 #}
+{% load component_tags %}
+<div class="frontmatter-component">
+    <div class="title">{% slot "title" %}Title{% endslot %}</div>
+    {% if_filled "subtitle" %}
+        <div class="subtitle">{% slot "subtitle" %}Optional subtitle{% endslot %}</div>
+    {% elif_filled "alt_subtitle" %}
+        <div class="subtitle">{% slot "alt_subtitle" %}Why would you want this?{% endslot %}</div>
+    {% else_filled %}
+       <div class="warning">Nothing filled!</div>
+    {% endif_filled %}
+</div>

--- a/tests/templates/template_with_illegal_super_recursion.html
+++ b/tests/templates/template_with_illegal_super_recursion.html
@@ -1,0 +1,4 @@
+{% load component_tags %}
+<header>
+  {% slot "header" %} Default content and {{ header.default }}{% endslot %}
+</header>

--- a/tests/templates/template_with_negated_conditional_slots.html
+++ b/tests/templates/template_with_negated_conditional_slots.html
@@ -1,0 +1,10 @@
+{# Example from django-components/issues/98 #}
+{% load component_tags %}
+<div class="frontmatter-component">
+    <div class="title">{% slot "title" %}Title{% endslot %}</div>
+    {% if_filled "subtitle" False %}
+       <div class="warning">Subtitle not filled!</div>
+    {% else_filled %}
+        <div class="subtitle">{% slot "alt_subtitle" %}Why would you want this?{% endslot %}</div>
+    {% endif_filled %}
+</div>

--- a/tests/templates/template_with_nonunique_slots.html
+++ b/tests/templates/template_with_nonunique_slots.html
@@ -1,4 +1,4 @@
 {% load component_tags %}
 <header>{% slot "header" %}Default header{% endslot %}</header>
-<main>{% slot "header" %}Default main header{% endslot %}</main> {# <- whoops! slot name 'header' used twice.
+<main>{% slot "header" %}Default main header{% endslot %}</main> {# <- whoops! slot name 'header' used twice. #}
 <footer>{% slot "footer" %}Default footer{% endslot %}</footer>

--- a/tests/templates/template_with_nonunique_slots.html
+++ b/tests/templates/template_with_nonunique_slots.html
@@ -1,0 +1,4 @@
+{% load component_tags %}
+<header>{% slot "header" %}Default header{% endslot %}</header>
+<main>{% slot "header" %}Default main header{% endslot %}</main> {# <- whoops! slot name 'header' used twice.
+<footer>{% slot "footer" %}Default footer{% endslot %}</footer>

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -157,8 +157,8 @@ class ContextTests(SimpleTestCase):
         template = Template(
             "{% load component_tags %}{% component_dependencies %}"
             "{% component_block 'parent_component' %}"
-            "{% slot 'content' %}{% component name='variable_display' "
-            "shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}{% endslot %}"
+            "{% fill 'content' %}{% component name='variable_display' "
+            "shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}{% endfill %}"
             "{% endcomponent_block %}"
         )
         rendered = template.render(Context())
@@ -181,8 +181,8 @@ class ContextTests(SimpleTestCase):
         template = Template(
             "{% load component_tags %}{% component_dependencies %}"
             "{% component_block 'parent_component' %}"
-            "{% slot 'content' %}{% component name='variable_display' "
-            "shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}{% endslot %}"
+            "{% fill 'content' %}{% component name='variable_display' "
+            "shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}{% endfill %}"
             "{% endcomponent_block %}"
         )
         rendered = template.render(Context())
@@ -248,8 +248,8 @@ class ContextTests(SimpleTestCase):
         template = Template(
             "{% load component_tags %}{% component_dependencies %}"
             "{% component_block 'parent_component' %}"
-            "{% slot 'content' %}{% component name='variable_display' "
-            "shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}{% endslot %}"
+            "{% fill 'content' %}{% component name='variable_display' "
+            "shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}{% endfill %}"
             "{% endcomponent_block %}"
         )
         rendered = template.render(
@@ -309,8 +309,8 @@ class ParentArgsTests(SimpleTestCase):
         template = Template(
             "{% load component_tags %}{% component_dependencies %}"
             "{% component_block 'parent_with_args' parent_value='passed_in' %}"
-            "{% slot 'content' %}{% component name='variable_display' "
-            "shadowing_variable='value_from_slot' new_variable=inner_parent_value %}{% endslot %}"
+            "{% fill 'content' %}{% component name='variable_display' "
+            "shadowing_variable='value_from_slot' new_variable=inner_parent_value %}{% endfill %}"
             "{%endcomponent_block %}"
         )
         rendered = template.render(Context())
@@ -373,8 +373,8 @@ class ContextCalledOnceTests(SimpleTestCase):
     def test_one_context_call_with_slot(self):
         template = Template(
             "{% load component_tags %}"
-            "{% component_block 'incrementer' %}{% slot 'content' %}"
-            "<p>slot</p>{% endslot %}{% endcomponent_block %}"
+            "{% component_block 'incrementer' %}{% fill 'content' %}"
+            "<p>slot</p>{% endfill %}{% endcomponent_block %}"
         )
         rendered = template.render(Context()).strip()
 
@@ -387,8 +387,8 @@ class ContextCalledOnceTests(SimpleTestCase):
     def test_one_context_call_with_slot_and_arg(self):
         template = Template(
             "{% load component_tags %}"
-            "{% component_block 'incrementer' value='3' %}{% slot 'content' %}"
-            "<p>slot</p>{% endslot %}{% endcomponent_block %}"
+            "{% component_block 'incrementer' value='3' %}{% fill 'content' %}"
+            "<p>slot</p>{% endfill %}{% endcomponent_block %}"
         )
         rendered = template.render(Context()).strip()
 

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -334,6 +334,21 @@ class ComponentSlottedTemplateTagTest(SimpleTestCase):
         """
         self.assertHTMLEqual(rendered, expected)
 
+    def test_missing_required_slot_raises_error(self):
+        class Component(component.Component):
+            template_name = "slotted_template_with_required_slot.html"
+
+        component.registry.register("test", Component)
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component_block 'test' %}
+            {% endcomponent_block %}
+            """
+        )
+        with self.assertRaises(TemplateSyntaxError):
+            template.render(Context({}))
+
 
 class SlottedTemplateRegressionTests(SimpleTestCase):
     def setUp(self):
@@ -902,9 +917,6 @@ class ComponentNestingTests(SimpleTestCase):
             {% endcomponent_block %}
             """
         )
-        import sys
-
-        sys.setrecursionlimit(100)
         rendered = template.render(Context({"items": [1, 2]}))
         expected = """
         <div class="dashboard-component">


### PR DESCRIPTION
(Breaking) changes to library usage:

- Component blocks pass content to component slots using a new `{% fill %}` tag.
- The meaning of the original `{% slot %}` tag is stricter: it now serves only to declare/open new slots in component templates.

Code changes:

- First crack at updating the documentation. It's not 100% ready.
- All tests updated to use `{% fill %}` where appropriate.
- New tests added to demonstrate component nesting.
- Unsure if correct: replaced the traversal of the node tree in _Component.get_processed_template()_ with a call to a rewritten _find_slot_nodes()_ method.
- Renamed some variables for greater clarity.

Potential future work in context of PR:

- As discussed in linked issue, `{{ slot.super }}`needs to be revised.
- Add `optional` modifier to slot tag. (Low effort)
- Add mechanism for checking if a slot has been filled (maybe out of scope but might as well)

(I've merged instead of rebased. Let me know if you prefer it the other way.)