### PR TITLE
Fix/263 performance regression

### DIFF
--- a/django_components/component.py
+++ b/django_components/component.py
@@ -1,4 +1,3 @@
-import copy
 from typing import (
     TYPE_CHECKING,
     ClassVar,
@@ -126,12 +125,13 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
         return self._outer_context or {}
 
     def get_updated_fill_stacks(self, context):
-        current_fill_stacks = context.get(FILLED_SLOTS_CONTEXT_KEY, None)
-        updated_fill_stacks = (
-            copy.deepcopy(current_fill_stacks)
-            if current_fill_stacks is not None
-            else {}
+        current_fill_stacks: Optional[Dict[str, List[FillNode]]] = context.get(
+            FILLED_SLOTS_CONTEXT_KEY, None
         )
+        updated_fill_stacks = {}
+        if current_fill_stacks:
+            for name, fill_nodes in current_fill_stacks.items():
+                updated_fill_stacks[name] = list(fill_nodes)
         for name, fill in self.instance_fills.items():
             if name in updated_fill_stacks:
                 updated_fill_stacks[name].append(fill)

--- a/sampleproject/components/calendar/calendar.html
+++ b/sampleproject/components/calendar/calendar.html
@@ -1,1 +1,13 @@
-<div class="calendar-component">Today's date is <span>{{ date }}</span></div>
+<div class="calendar-component">
+  <div>Today's date is <span>{{ date }}</span></div>
+  <div>Your to-dos:</div>
+  <ul>
+    <li>
+      {% component_block "todo" %}
+        {% fill "todo_text" %}
+          Stop forgetting the milk!
+        {% endfill %}
+      {% endcomponent_block %}
+    </li>
+  </ul>
+</div>

--- a/sampleproject/components/todo/todo.html
+++ b/sampleproject/components/todo/todo.html
@@ -1,0 +1,4 @@
+<div class="todo-item">
+  {% slot "todo_text" %}
+  {% endslot %}
+</div>

--- a/sampleproject/components/todo/todo.py
+++ b/sampleproject/components/todo/todo.py
@@ -1,0 +1,9 @@
+from django_components import component
+
+
+@component.register("todo")
+class Calendar(component.Component):
+    # Note that Django will look for templates inside `[your apps]/components` dir and
+    # `[project root]/components` dir. To customize which template to use based on context
+    # you can override def get_template_name() instead of specifying the below variable.
+    template_name = "todo/todo.html"


### PR DESCRIPTION
Fixes #263. 

Cause: deep-copying of dict of lists of fillnodes created a deeeeep stack of further calls to copy.deepcopy(). 
Solution: Replaced deep-copying with a for-loop that copies only the lists (instead of everything inside them). 

Issue reporter @VojtechPetru verified the solution resolves the issue by testing on the same real-life code where the issue was first observed.