### PR TITLE
Implement #231 – default slot filling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ And this is what gets rendered (plus the CSS and Javascript you've specified):
 
 Read on to learn about the details!
 
-# Release notes
+## Release notes
 
-*Version 0.27* includes an additional installable app *django_components.safer_staticfiles*. It provides the same behavior as *django.contrib.staticfiles* but with extra security guarantees (more info below in Security Notes). 
+*Version 0.28* introduces 'implicit' slot filling and the `default` option for `slot` tags.  
+
+*Version 0.27* adds a second installable app: *django_components.safer_staticfiles*. It provides the same behavior as *django.contrib.staticfiles* but with extra security guarantees (more info below in Security Notes). 
 
 *Version 0.26* changes the syntax for `{% slot %}` tags. From now on, we separate defining a slot (`{% slot %}`) from filling a slot with content (`{% fill %}`). This means you will likely need to change a lot of slot tags to fill. We understand this is annoying, but it's the only way we can get support for nested slots that fill in other slots, which is a very nice feature to have access to. Hoping that this will feel worth it!
 
@@ -28,11 +30,11 @@ Read on to learn about the details!
 
 *Version 0.17* renames `Component.context` and `Component.template` to `get_context_data` and `get_template_name`. The old methods still work, but emit a deprecation warning. This change was done to sync naming with Django's class based views, and make using django-components more familiar to Django users. `Component.context` and `Component.template` will be removed when version 1.0 is released.
 
-# Security notes 🚨
+## Security notes 🚨
 
 *You are advised to read this section before using django-components in production.*
 
-## Static files
+### Static files
 
 Components can be organized however you prefer.
 That said, our prefered way is to keep the files of a component close together by bundling them in the same directory.
@@ -58,7 +60,7 @@ INSTALLED_APPS = [
 If you are on an older version of django-components, your alternatives are a) passing `--ignore <pattern>` options to the _collecstatic_ CLI command, or b) defining a subclass of StaticFilesConfig.
 Both routes are described in the official [docs of the _staticfiles_ app](https://docs.djangoproject.com/en/4.2/ref/contrib/staticfiles/#customizing-the-ignored-pattern-list).  
 
-# Installation
+## Installation
 
 Install the app into your environment:
 
@@ -106,7 +108,7 @@ STATICFILES_DIRS = [
 ]
 ```
 
-## Optional
+### Optional
 
 To avoid loading the app in each template using ``` {% load django_components %} ```, you can add the tag as a 'builtin' in settings.py
 
@@ -128,7 +130,7 @@ TEMPLATES = [
 
 Read on to find out how to build your first component!
 
-# Compatiblity
+## Compatiblity
 
 Django-components supports all <a href="https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django">officially supported versions</a> of Django and Python.
 
@@ -140,7 +142,7 @@ Django-components supports all <a href="https://docs.djangoproject.com/en/dev/fa
 | 3.9            | 3.2, 4.0                 |
 | 3.10           | 4.0                      |
 
-# Create your first component
+## Create your first component
 
 A component in django-components is the combination of four things: CSS, Javascript, a Django template, and some Python code to put them all together.
 
@@ -172,7 +174,7 @@ Now you need a Django template for your component. Feel free to define more vari
 ```htmldjango
 {# In a file called [project root]/components/calendar/calendar.html #}
 <div class="calendar-component">Today's date is <span>{{ date }}</span></div>
-```
+``  `
 
 Finally, we use django-components to tie this together. Start by creating a file called `calendar.py` in your component calendar directory. It will be auto-detected and loaded by the app.
 
@@ -201,7 +203,7 @@ class Calendar(component.Component):
 
 And voilá!! We've created our first component.
 
-# Use the component in a template
+## Use the component in a template
 
 First load the `component_tags` tag library, then use the `component_[js/css]_dependencies` and `component` tags to render the component to the page.
 
@@ -238,14 +240,16 @@ The output from the above template will be:
 
 This makes it possible to organize your front-end around reusable components. Instead of relying on template tags and keeping your CSS and Javascript in the static directory.
 
-# Using slots in templates
+## Using slots in templates
 
 _New in version 0.26_:
 
 - The `slot` tag now serves only to declare new slots inside the component template.
   - To override the content of a declared slot, use the newly introduced `fill` tag instead.
 - Whereas unfilled slots used to raise a warning, filling a slot is now optional by default.
-  - To indicate that a slot must be filled, the new keyword `required` should be added at the end of the `slot` tag.  
+  - To indicate that a slot must be filled, the new `required` option should be added at the end of the `slot` tag.
+
+---
 
 Components support something called 'slots'. 
 When a component is used inside another template, slots allow the parent template to override specific parts of the child component by passing in different content.
@@ -254,9 +258,9 @@ This mechanism makes components more reusable and composable.
 In the example below we introduce two block tags that work hand in hand to make this work. These are...
 
 - `{% slot <name> %}`/`{% endslot %}`: Declares a new slot in the component template.
-- `{% fill <name> %}`/`{% endfill %}`: (Used inside a component block.) Fills a declared slot with the specified content.
+- `{% fill <name> %}`/`{% endfill %}`: (Used inside a `component_block` tag pair.) Fills a declared slot with the specified content.
 
-Let's update our calendar component to support more customization by updating our calendar.html template.
+Let's update our calendar component to support more customization. We'll add `slot` tag pairs to its template, _calendar.html_. 
 
 ```htmldjango
 <div class="calendar-component">
@@ -277,7 +281,7 @@ When using the component, you specify which slots you want to fill and where you
 {% endcomponent_block %}
 ```
 
-Since the header block is unspecified, it's taken from the base template. If you put this in a template, and send in date=2020-06-06, this is what's rendered:
+Since the header block is unspecified, it's taken from the base template. If you put this in a template, and pass in `date=2020-06-06`, this is what gets rendered:
 
 ```htmldjango
 <div class="calendar-component">
@@ -288,10 +292,84 @@ Since the header block is unspecified, it's taken from the base template. If you
         Can you believe it's already <span>2020-06-06</span>??
     </div>
 </div>
-
 ```
 
-As you can see, component slots lets you write reusable containers, that you fill out when you use a component. This makes for highly reusable components, that can be used in different circumstances.
+As you can see, component slots lets you write reusable containers that you fill in when you use a component. This makes for highly reusable components that can be used in different circumstances.
+
+It can become tedious to use `fill` tags everywhere, especially when you're using a component that declares only one slot. To make things easier, `slot` tags can be marked with an optional keyword: `default`. When added to the end of the tag (as shown below), this option lets you pass filling content directly in the body of a `component_block` tag pair – without using a `fill` tag. Choose carefully, though: a component template may contain at most one slot that is marked as `default`. The `default` option can be combined with other slot options, e.g. `required`.
+
+Here's the same example as before, except with default slots and implicit filling.
+
+The template:
+
+```htmldjango 
+<div class="calendar-component">
+    <div class="header">
+        {% slot "header" %}Calendar header{% endslot %}
+    </div>
+    <div class="body">
+        {% slot "body" default %}Today's date is <span>{{ date }}</span>{% endslot %}
+    </div>
+</div>
+```
+
+Including the component (notice how the `fill` tag is omitted):
+
+```htmldjango
+{% component_block "calendar" date="2020-06-06" %}
+    Can you believe it's already <span>{{ date }}</span>??
+{% endcomponent_block %}
+```
+
+The rendered result (exactly the same as before):
+
+```html
+<div class="calendar-component">
+    <div class="header">
+        Calendar header
+    </div>
+    <div class="body">
+        Can you believe it's already <span>2020-06-06</span>??
+    </div>
+</div>
+```
+
+You may be tempted to combine implicit fills with explicit `fill` tags. This will not work. The following component template will raise an error when compiled.
+
+```htmldjango
+{# DON'T DO THIS #}
+{% component_block "calendar" date="2020-06-06" %}
+    {% fill "header" %}Totally new header!{% endfill %}
+    Can you believe it's already <span>{{ date }}</span>??
+{% endcomponent_block %}
+```
+
+By contrast, it is permitted to use `fill` tags in nested components, e.g.:
+
+```htmldjango
+{% component_block "calendar" date="2020-06-06" %}
+    {% component_block "beautiful-box" %}
+        {% fill "content" %} Can you believe it's already <span>{{ date }}</span>?? {% endfill %}
+    {% endcomponent_block
+{% endcomponent_block %}
+```
+
+This is fine too:
+
+```htmldjango
+{% component_block "calendar" date="2020-06-06" %}
+    {% fill "header" %}
+        {% component_block "calendar-header" %}
+            Super Special Calendar Header
+        {% endcomponent_block
+    {% endfill %}
+{% endcomponent_block %}
+```
+
+
+### Advanced
+
+#### Re-using content defined in the original slot
 
 Certain properties of a slot can be accessed from within a 'fill' context. They are provided as attributes on a user-defined alias of the targeted slot. For instance, let's say you're filling a slot called 'body'. To access properties of this slot, alias it using the 'as' keyword to a new name -- or keep the original name. With the new slot alias, you can call `<alias>.default` to insert the default content.
 
@@ -314,9 +392,8 @@ Produces:
 </div>
 ```
 
-## Advanced
 
-### Conditional slots
+#### Conditional slots
 
 _Added in version 0.26._
 
@@ -407,7 +484,7 @@ only if the slot 'subtitle' is _not_ filled.
 {% endif_filled %}
 ```
 
-# Component context and scope
+## Component context and scope
 
 By default, components can access context variables from the parent template, just like templates that are included with the `{% include %}` tag. Just like with `{% include %}`, if you don't want the component template to have access to the parent context, add `only` to the end of the `{% component %}` (or `{% component_block %}` tag):
 
@@ -420,11 +497,11 @@ NOTE: `{% csrf_token %}` tags need access to the top-level context, and they wil
 Components can also access the outer context in their context methods by accessing the property `outer_context`.
 
 
-# Available settings
+## Available settings
 
 All library settings are handled from a global COMPONENTS variable that is read from settings.py. By default you don't need it set, there are resonable defaults.
 
-## Configure the module where components are loaded from
+### Configure the module where components are loaded from
 
 Configure the location where components are loaded. To do this, add a COMPONENTS variable to you settings.py with a list of python paths to load. This allows you to build a structure of components that are independent from your apps.
 
@@ -438,7 +515,7 @@ COMPONENTS = {
 }
 ```
 
-## Disable autodiscovery
+### Disable autodiscovery
 
 If you specify all the component locations with the setting above and have a lot of apps, you can (very) slightly speed things up by disabling autodiscovery.
 
@@ -448,7 +525,7 @@ COMPONENTS = {
 }
 ```
 
-## Tune the template cache
+### Tune the template cache
 
 Each time a template is rendered it is cached to a global in-memory cache (using Python's lru_cache decorator). This speeds up the next render of the component. As the same component is often used many times on the same page, these savings add up. By default the cache holds 128 component templates in memory, which should be enough for most sites. But if you have a lot of components, or if you are using the `template` method of a component to render lots of dynamic templates, you can increase this number. To remove the cache limit altogether and cache everything, set template_cache_size to `None`.
 
@@ -458,7 +535,7 @@ COMPONENTS = {
 }
 ```
 
-# Install locally and run the tests
+## Install locally and run the tests
 
 Start by forking the project by clicking the **Fork button** up in the right corner in the GitHub . This makes a copy of the repository in your own name. Now you can clone this repository locally and start adding features:
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Now you need a Django template for your component. Feel free to define more vari
 ```htmldjango
 {# In a file called [project root]/components/calendar/calendar.html #}
 <div class="calendar-component">Today's date is <span>{{ date }}</span></div>
-``  `
+```
 
 Finally, we use django-components to tie this together. Start by creating a file called `calendar.py` in your component calendar directory. It will be auto-detected and loaded by the app.
 

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -154,7 +154,6 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
                 name: (nodelist, alias)
                 for name, nodelist, alias in self.fill_content
             }
-
         slot_name2fill_content: Dict[SlotName, Optional[FillContent]] = {}
         default_slot_already_encountered: bool = False
         for node in template.nodelist.get_nodes_by_type(

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -1,13 +1,5 @@
 from collections import ChainMap
-from typing import (
-    Any,
-    ClassVar,
-    Dict,
-    Iterable,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, ClassVar, Dict, Iterable, Optional, Tuple, Union
 
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.widgets import Media, MediaDefiningClass
@@ -142,7 +134,6 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
     def _process_template_and_update_filled_slot_context(
         self, context: Context, template: Template
     ) -> FilledSlotsContext:
-
         fill_target2content: Dict[Optional[str], FillContent]
         if isinstance(self.fill_content, NodeList):
             fill_target2content = {None: (self.fill_content, None)}

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -6,7 +6,6 @@ from typing import (
     Iterable,
     Optional,
     Tuple,
-    TypeVar,
     Union,
 )
 

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -103,7 +103,7 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
             dfs_iter_slots_in_nodelist(template.nodelist, template.name)
         )
 
-    def get_template(self, context, template_name: Optional[str] = None):
+    def get_template(self, context, template_name: Optional[str] = None) -> Template:
         if template_name is None:
             template_name = self.get_template_name(context)
         template = get_template(template_name).template
@@ -153,6 +153,7 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
         all_slots: List["SlotNode"] = self.get_declared_slots(
             context, component_template
         )
+        # breakpoint()
         # Checks that
         # - Each declared slot has a unique name.
         # - At most 1 slot is marked as 'default'.

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -40,8 +40,6 @@ from django_components.templatetags.component_tags import (
     SlotNode,
 )
 
-T = TypeVar("T")
-
 
 class SimplifiedInterfaceMediaDefiningClass(MediaDefiningClass):
     def __new__(mcs, name, bases, attrs):

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -165,21 +165,21 @@ class Component(metaclass=SimplifiedInterfaceMediaDefiningClass):
                     f"Slot name '{slot_name}' re-used within the same template. "
                     f"Slot names must be unique."
                     f"To fix, check template '{component_template.name}' "
-                    f"of component'{self._component_name}'."
+                    f"of component '{self._component_name}'."
                 )
             if slot.is_default:
                 if encountered_default_slot:
                     raise TemplateSyntaxError(
                         "Only one component slot may be marked as 'default'. "
                         f"To fix, check template '{component_template.name}' "
-                        f"of component'{self._component_name}'."
+                        f"of component '{self._component_name}'."
                     )
                 else:
                     encountered_default_slot = True
             slots[slot_name] = slot
         # All fill nodes must correspond to a declared slot.
-        #  Exempt from constraint are implicit fills, which match a slot marked
-        #  as 'default'
+        # Exempt from constraint are implicit fills, which match a slot marked
+        # as 'default'
         unmatchable_fills = fills.keys() - slots.keys()
         if not unmatchable_fills:
             return

--- a/django_components/component_registry.py
+++ b/django_components/component_registry.py
@@ -34,3 +34,24 @@ class ComponentRegistry(object):
 
     def clear(self):
         self._registry = {}
+
+
+# This variable represents the global component registry
+registry = ComponentRegistry()
+
+
+def register(name):
+    """Class decorator to register a component.
+
+    Usage:
+
+    @register("my_component")
+    class MyComponent(component.Component):
+        ...
+    """
+
+    def decorator(component):
+        registry.register(name=name, component=component)
+        return component
+
+    return decorator

--- a/django_components/middleware.py
+++ b/django_components/middleware.py
@@ -41,7 +41,6 @@ class ComponentDependencyMiddleware:
 
 
 def process_response_content(content):
-
     component_names_seen = {
         match.group("name")
         for match in COMPONENT_COMMENT_REGEX.finditer(content)

--- a/django_components/middleware.py
+++ b/django_components/middleware.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.forms import Media
 from django.http import StreamingHttpResponse
 
+from django_components.component_registry import registry
+
 RENDERED_COMPONENTS_CONTEXT_KEY = "_COMPONENT_DEPENDENCIES"
 CSS_DEPENDENCY_PLACEHOLDER = '<link name="CSS_PLACEHOLDER">'
 JS_DEPENDENCY_PLACEHOLDER = '<script name="JS_PLACEHOLDER"></script>'
@@ -39,7 +41,6 @@ class ComponentDependencyMiddleware:
 
 
 def process_response_content(content):
-    from django_components.component import registry
 
     component_names_seen = {
         match.group("name")

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -226,7 +226,6 @@ class SlotNode(Node):
                     f"Slot '{self.name}' is marked as 'required' (i.e. non-optional), "
                     f"yet no fill is provided. Check template '{self.template_name}'"
                 )
-        # //
         # Get nodelist and add alias variables to context.
         extra_context = {}
         if fill_node:
@@ -237,7 +236,6 @@ class SlotNode(Node):
                 extra_context[resolved_alias_name] = aliased_slot_var
         else:
             nodelist = self.nodelist  # slot nodelist
-        # //
 
         with context.update(extra_context):
             return nodelist.render(context)

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -670,6 +670,10 @@ def parse_if_filled_bits(
             f"{bits[0]} tag arguments '{' '.join(args)}' do not match pattern "
             f"'<slotname> (<is_positive>)'"
         )
+    if not is_wrapped_in_quotes(slot_name):
+        raise TemplateSyntaxError(
+            f"First argument of '{bits[0]}' must be a quoted string 'literal'."
+        )
     slot_name = strip_quotes(slot_name)
     return slot_name, is_positive
 

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -88,7 +88,9 @@ def component_dependencies_tag(preload=""):
         preloaded_dependencies = []
         for component in get_components_from_preload_str(preload):
             preloaded_dependencies.append(
-                RENDERED_COMMENT_TEMPLATE.format(name=component.registered_name)
+                RENDERED_COMMENT_TEMPLATE.format(
+                    name=component.registered_name
+                )
             )
         return mark_safe(
             "\n".join(preloaded_dependencies)
@@ -111,9 +113,13 @@ def component_css_dependencies_tag(preload=""):
         preloaded_dependencies = []
         for component in get_components_from_preload_str(preload):
             preloaded_dependencies.append(
-                RENDERED_COMMENT_TEMPLATE.format(name=component.registered_name)
+                RENDERED_COMMENT_TEMPLATE.format(
+                    name=component.registered_name
+                )
             )
-        return mark_safe("\n".join(preloaded_dependencies) + CSS_DEPENDENCY_PLACEHOLDER)
+        return mark_safe(
+            "\n".join(preloaded_dependencies) + CSS_DEPENDENCY_PLACEHOLDER
+        )
     else:
         rendered_dependencies = []
         for component in get_components_from_registry(component_registry):
@@ -130,9 +136,13 @@ def component_js_dependencies_tag(preload=""):
         preloaded_dependencies = []
         for component in get_components_from_preload_str(preload):
             preloaded_dependencies.append(
-                RENDERED_COMMENT_TEMPLATE.format(name=component.registered_name)
+                RENDERED_COMMENT_TEMPLATE.format(
+                    name=component.registered_name
+                )
             )
-        return mark_safe("\n".join(preloaded_dependencies) + JS_DEPENDENCY_PLACEHOLDER)
+        return mark_safe(
+            "\n".join(preloaded_dependencies) + JS_DEPENDENCY_PLACEHOLDER
+        )
     else:
         rendered_dependencies = []
         for component in get_components_from_registry(component_registry):
@@ -262,7 +272,9 @@ def do_slot(parser, token):
     if 1 <= len(args) <= 3:
         slot_name, *options = args
         if not is_wrapped_in_quotes(slot_name):
-            raise TemplateSyntaxError(f"'{bits[0]}' name must be a string 'literal'.")
+            raise TemplateSyntaxError(
+                f"'{bits[0]}' name must be a string 'literal'."
+            )
         slot_name = strip_quotes(slot_name)
         modifiers_count = len(options)
         if SLOT_REQUIRED_OPTION_KEYWORD in options:
@@ -323,9 +335,7 @@ class NamedFillNode(BaseFillNode):
         self.alias_fexp = alias_fexp
 
     def __repr__(self):
-        return (
-            f"<{type(self)} Name: {self.name_fexp}. Contents: {repr(self.nodelist)}.>"
-        )
+        return f"<{type(self)} Name: {self.name_fexp}. Contents: {repr(self.nodelist)}.>"
 
 
 class ImplicitFillNode(BaseFillNode):
@@ -409,7 +419,9 @@ class ComponentNode(Node):
 
     def render(self, context: Context):
         resolved_component_name = self.name_fexp.resolve(context)
-        component_cls: Type[Component] = component_registry.get(resolved_component_name)
+        component_cls: Type[Component] = component_registry.get(
+            resolved_component_name
+        )
 
         # Resolve FilterExpressions and Variables that were passed as args to the
         # component, then call component's context method
@@ -434,13 +446,15 @@ class ComponentNode(Node):
                     resolved_alias: str = fill_node.alias_fexp.resolve(context)
                     if not resolved_alias.isidentifier():
                         raise TemplateSyntaxError(
-                            f"Fill tag alias '{resolved_alias}' in component "
+                            f"Fill tag alias '{fill_node.alias_fexp.var}' in component "
                             f"{resolved_component_name} does not resolve to "
-                            f"a valid Python identifier."
+                            f"a valid Python identifier. Got: '{resolved_alias}'."
                         )
                 else:
                     resolved_alias: None = None
-                fill_content.append((resolved_name, fill_node.nodelist, resolved_alias))
+                fill_content.append(
+                    (resolved_name, fill_node.nodelist, resolved_alias)
+                )
 
         component: Component = component_cls(
             registered_name=resolved_component_name,
@@ -576,7 +590,10 @@ def is_whitespace_token(token):
 
 
 def is_block_tag_token(token, name):
-    return token.token_type == TokenType.BLOCK and token.split_contents()[0] == name
+    return (
+        token.token_type == TokenType.BLOCK
+        and token.split_contents()[0] == name
+    )
 
 
 @register.tag(name="if_filled")
@@ -689,7 +706,9 @@ class _IfSlotFilledBranchNode(Node):
         raise NotImplementedError
 
 
-class IfSlotFilledConditionBranchNode(_IfSlotFilledBranchNode, TemplateAwareNodeMixin):
+class IfSlotFilledConditionBranchNode(
+    _IfSlotFilledBranchNode, TemplateAwareNodeMixin
+):
     def __init__(
         self,
         slot_name: str,
@@ -702,7 +721,9 @@ class IfSlotFilledConditionBranchNode(_IfSlotFilledBranchNode, TemplateAwareNode
 
     def evaluate(self, context) -> bool:
         try:
-            filled_slots: FilledSlotsContext = context[FILLED_SLOTS_CONTENT_CONTEXT_KEY]
+            filled_slots: FilledSlotsContext = context[
+                FILLED_SLOTS_CONTENT_CONTEXT_KEY
+            ]
         except KeyError:
             raise TemplateSyntaxError(
                 f"Attempted to render {type(self).__name__} outside a Component rendering context."
@@ -803,7 +824,9 @@ def is_wrapped_in_quotes(s):
 
 
 def is_dependency_middleware_active():
-    return getattr(settings, "COMPONENTS", {}).get("RENDER_DEPENDENCIES", False)
+    return getattr(settings, "COMPONENTS", {}).get(
+        "RENDER_DEPENDENCIES", False
+    )
 
 
 def norm_and_validate_name(name: str, tag: str, context: Optional[str] = None):
@@ -815,7 +838,8 @@ def norm_and_validate_name(name: str, tag: str, context: Optional[str] = None):
     if not name.isidentifier():
         context = f" in '{context}'" if context else ""
         raise TemplateSyntaxError(
-            f"{tag} name '{name}'{context} " "is not a valid Python identifier."
+            f"{tag} name '{name}'{context} "
+            "is not a valid Python identifier."
         )
     return name
 

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Iterator
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
 
 from django import template
 from django.conf import settings
@@ -7,10 +7,10 @@ from django.template.base import (
     Node,
     NodeList,
     TemplateSyntaxError,
+    TextNode,
     TokenType,
     Variable,
     VariableDoesNotExist,
-    TextNode,
 )
 from django.template.defaulttags import CommentNode
 from django.template.library import parse_bits

--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -162,18 +162,6 @@ class UserSlotVar:
     def default(self) -> str:
         return mark_safe(self._slot.nodelist.render(self._context))
 
-    # (lemontheme): If 'default' is accepted as option keyword for slot tags,
-    #  then I propose 'original' replaces 'default' in the 'slot.super' sense.
-    #  Otherwise, we would have both
-    #  - {% slot ... default %} ...
-    #  and
-    #  - {% fill ... as <alias> %} <alias>.default {%endfill %}.
-    #  I'm afraid this risks being a source of confusion, as users might wrongly assume
-    #  that there is a link between the two separate usages of 'default'.
-    @property
-    def original(self) -> str:
-        return self.default
-
 
 class SlotNode(Node):
     def __init__(

--- a/sampleproject/components/calendar/calendar.html
+++ b/sampleproject/components/calendar/calendar.html
@@ -9,5 +9,11 @@
         {% endfill %}
       {% endcomponent_block %}
     </li>
+    <li>
+      {% component_block "todo" %}
+        {# As of v0.28, 'fill' tag optional for 1-slot filling if component template specifies a 'default' slot #}
+        Wear all-white clothes to laser tag tournament.
+      {% endcomponent_block %}
+    </li>
   </ul>
 </div>

--- a/sampleproject/components/todo/todo.html
+++ b/sampleproject/components/todo/todo.html
@@ -1,4 +1,4 @@
 <div class="todo-item">
-  {% slot "todo_text" %}
+  {% slot "todo_text" default %}
   {% endslot %}
 </div>

--- a/tests/templates/template_with_default_and_required_slot.html
+++ b/tests/templates/template_with_default_and_required_slot.html
@@ -1,5 +1,5 @@
 {% load component_tags %}
 <div>
     <header>{% slot "header" %}Your Header Here{% endslot %}</header>
-    <main>{% slot "main" default required %}East to override{% endslot %}</main>
+    <main>{% slot "main" default required %}Easy to override{% endslot %}</main>
 </div>

--- a/tests/templates/template_with_default_and_required_slot.html
+++ b/tests/templates/template_with_default_and_required_slot.html
@@ -1,0 +1,5 @@
+{% load component_tags %}
+<div>
+    <header>{% slot "header" %}Your Header Here{% endslot %}</header>
+    <main>{% slot "main" default required %}East to override{% endslot %}</main>
+</div>

--- a/tests/templates/template_with_default_slot.html
+++ b/tests/templates/template_with_default_slot.html
@@ -1,0 +1,4 @@
+{% load component_tags %}
+<div>
+    <main>{% slot "main" default %}Easy to override{% endslot %}</main>
+</div>

--- a/tests/templates/template_with_if_elif_else_conditional_slots.html
+++ b/tests/templates/template_with_if_elif_else_conditional_slots.html
@@ -2,7 +2,7 @@
 {% load component_tags %}
 <div class="frontmatter-component">
     <div class="title">{% slot "title" %}Title{% endslot %}</div>
-    {% if_filled "subtitle" %}
+    {% if_filled 'subtitle'%}
         <div class="subtitle">{% slot "subtitle" %}Optional subtitle{% endslot %}</div>
     {% elif_filled "alt_subtitle" %}
         <div class="subtitle">{% slot "alt_subtitle" %}Why would you want this?{% endslot %}</div>

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -489,16 +489,13 @@ class ComponentSlottedTemplateTagTest(SimpleTestCase):
     def test_component_template_cannot_have_multiple_default_slots(self):
 
         class BadComponent(component.Component):
-
-            template_name = ...
-
             def get_template(
-                self, context, template_name=None
+                self, context, template_name: Optional[str] = None
             ) -> Template:
                 # language=html
                 return Template(
                     """
-                    {% load component_tags %}
+
                     <div>
                     {% slot "icon" %} {% endslot default %}
                     {% slot "description" %} {% endslot default %}

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -903,9 +903,9 @@ class TemplateSyntaxErrorTests(SimpleTestCase):
         component.registry.clear()
 
     def test_variable_outside_fill_tag_compiles_w_out_error(self):
-        # As of v0.28 this isvalid, provided the component registered under "test"
-        #  contains a slot tag marked as 'default'. This is verified outside
-        #  template compilation time.
+        # As of v0.28 this is valid, provided the component registered under "test"
+        # contains a slot tag marked as 'default'. This is verified outside
+        # template compilation time.
         Template(
             """
             {% load component_tags %}
@@ -916,9 +916,9 @@ class TemplateSyntaxErrorTests(SimpleTestCase):
         )
 
     def test_text_outside_fill_tag_is_not_error(self):
-        # As of v0.28 this isvalid, provided the component registered under "test"
-        #  contains a slot tag marked as 'default'. This is verified outside
-        #  template compilation time.
+        # As of v0.28 this is valid, provided the component registered under "test"
+        # contains a slot tag marked as 'default'. This is verified outside
+        # template compilation time.
         Template(
             """
             {% load component_tags %}

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -492,10 +492,9 @@ class ComponentSlottedTemplateTagTest(SimpleTestCase):
             def get_template(
                 self, context, template_name: Optional[str] = None
             ) -> Template:
-                # language=html
                 return Template(
                     """
-
+                    {% load django_components %}
                     <div>
                     {% slot "icon" %} {% endslot default %}
                     {% slot "description" %} {% endslot default %}

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -487,7 +487,6 @@ class ComponentSlottedTemplateTagTest(SimpleTestCase):
             template.render(Context({}))
 
     def test_component_template_cannot_have_multiple_default_slots(self):
-
         class BadComponent(component.Component):
             def get_template(
                 self, context, template_name: Optional[str] = None
@@ -501,6 +500,7 @@ class ComponentSlottedTemplateTagTest(SimpleTestCase):
                     </div>
                     """
                 )
+
         c = BadComponent("name")
         with self.assertRaises(TemplateSyntaxError):
             c.render(Context({}))


### PR DESCRIPTION
This PR adds default slot filling as described in #231.

Here's an example (copied from the updated docs):

### Example

The template:

```htmldjango 
<div class="calendar-component">
    <div class="header">
        {% slot "header" %}Calendar header{% endslot %}
    </div>
    <div class="body">
        {% slot "body" default %}Today's date is <span>{{ date }}</span>{% endslot %}
    </div>
</div>
```

Including the component (notice how the `fill` tag is omitted):

```htmldjango
{% component_block "calendar" date="2020-06-06" %}
    Can you believe it's already <span>{{ date }}</span>??
{% endcomponent_block %}
```

The rendered result (exactly the same as before):

```html
<div class="calendar-component">
    <div class="header">
        Calendar header
    </div>
    <div class="body">
        Can you believe it's already <span>2020-06-06</span>??
    </div>
</div>
```

---

### Main changes:

- New `default` option added to `slot` tags.
- Component_block parsing updated to deal with 'bare'/'implicit' (still looking for the right term) filling.

Additional changes:

- Tests
- Updated the README + minor cosmetic changes
- Added example to sampleproject

To discuss:

- With the new `default` keyword, we're overloading the 'default' concept slightly, since it's also used in the `<fill_alias>.super` usage (i.e. where we used to have `slot.super`). In one of my code comments, I argue it might be better to drop the second use of 'default' and use `<fill_alias>.original` instead.