### PR TITLE
Use valid script tag HTML to avoid console errors

### DIFF
--- a/django_components/middleware.py
+++ b/django_components/middleware.py
@@ -6,14 +6,14 @@ from django.http import StreamingHttpResponse
 
 RENDERED_COMPONENTS_CONTEXT_KEY = "_COMPONENT_DEPENDENCIES"
 CSS_DEPENDENCY_PLACEHOLDER = '<link name="CSS_PLACEHOLDER">'
-JS_DEPENDENCY_PLACEHOLDER = '<script name="JS_PLACEHOLDER">'
+JS_DEPENDENCY_PLACEHOLDER = '<script name="JS_PLACEHOLDER"></script>'
 
 SCRIPT_TAG_REGEX = re.compile("<script")
 COMPONENT_COMMENT_REGEX = re.compile(rb"<!-- _RENDERED (?P<name>\w+?) -->")
 PLACEHOLDER_REGEX = re.compile(
     rb"<!-- _RENDERED (?P<name>\w+?) -->"
     rb'|<link name="CSS_PLACEHOLDER">'
-    rb'|<script name="JS_PLACEHOLDER">'
+    rb'|<script name="JS_PLACEHOLDER"></script>'
 )
 
 


### PR DESCRIPTION
This pull request updates the script tag that's placed by django-components in order to render component dependencies. Currently, the script tag is not valid and ends up causing errors in the console and breaking the next script that's defined.

![image](https://user-images.githubusercontent.com/1695613/233348200-bdbbe7b7-a637-4508-bf4c-9a7cc3f168e0.png)

This is currently the largest event in our brand new Sentry front-end setup, so I feel as if it might grow in production 😅 