### PR TITLE
ignore .pyc files in collectstatic management command

### DIFF
--- a/django_components/safer_staticfiles/apps.py
+++ b/django_components/safer_staticfiles/apps.py
@@ -15,4 +15,8 @@ class SaferStaticFilesConfig(StaticFilesConfig):
     default = (
         True  # Ensure that _this_ app is registered, as opposed to parent cls.
     )
-    ignore_patterns = StaticFilesConfig.ignore_patterns + ["*.py", "*.html"]
+    ignore_patterns = StaticFilesConfig.ignore_patterns + [
+        "*.py",
+        "*.html",
+        "*.pyc",
+    ]


### PR DESCRIPTION
Ignore also _.pyc_ files when running `collectstatic` (compiled Python files inside `__pycache__` folder).

Related to https://github.com/EmilStenstrom/django-components/pull/261.