### PR TITLE
Add support for - and / in component names in middleware

### DIFF
--- a/django_components/middleware.py
+++ b/django_components/middleware.py
@@ -11,9 +11,9 @@ CSS_DEPENDENCY_PLACEHOLDER = '<link name="CSS_PLACEHOLDER">'
 JS_DEPENDENCY_PLACEHOLDER = '<script name="JS_PLACEHOLDER"></script>'
 
 SCRIPT_TAG_REGEX = re.compile("<script")
-COMPONENT_COMMENT_REGEX = re.compile(rb"<!-- _RENDERED (?P<name>\w+?) -->")
+COMPONENT_COMMENT_REGEX = re.compile(rb"<!-- _RENDERED (?P<name>[\w\-/]+?) -->")
 PLACEHOLDER_REGEX = re.compile(
-    rb"<!-- _RENDERED (?P<name>[\w\-\/]+?) -->"
+    rb"<!-- _RENDERED (?P<name>[\w\-/]+?) -->"
     rb'|<link name="CSS_PLACEHOLDER">'
     rb'|<script name="JS_PLACEHOLDER"></script>'
 )

--- a/django_components/middleware.py
+++ b/django_components/middleware.py
@@ -11,7 +11,9 @@ CSS_DEPENDENCY_PLACEHOLDER = '<link name="CSS_PLACEHOLDER">'
 JS_DEPENDENCY_PLACEHOLDER = '<script name="JS_PLACEHOLDER"></script>'
 
 SCRIPT_TAG_REGEX = re.compile("<script")
-COMPONENT_COMMENT_REGEX = re.compile(rb"<!-- _RENDERED (?P<name>[\w\-/]+?) -->")
+COMPONENT_COMMENT_REGEX = re.compile(
+    rb"<!-- _RENDERED (?P<name>[\w\-/]+?) -->"
+)
 PLACEHOLDER_REGEX = re.compile(
     rb"<!-- _RENDERED (?P<name>[\w\-/]+?) -->"
     rb'|<link name="CSS_PLACEHOLDER">'

--- a/tests/test_dependency_rendering.py
+++ b/tests/test_dependency_rendering.py
@@ -418,7 +418,7 @@ class ComponentMediaRenderingTests(SimpleTestCase):
                 f"{{% component '{component_name}' variable='value' %}}"
             )
             rendered = create_and_process_template_response(template)
-            self.assertEqual(
+            self.assertHTMLEqual(
                 (
                     '<script src="script.js"></script>'
                     '<link href="style.css" media="all" rel="stylesheet">'

--- a/tests/test_dependency_rendering.py
+++ b/tests/test_dependency_rendering.py
@@ -399,8 +399,14 @@ class ComponentMediaRenderingTests(SimpleTestCase):
         request = Mock()
         self.assertEqual(response, middleware(request=request))
 
-    def test_middleware_response_with_components_with_slash_dash_and_underscore(self):
-        component_names = ["test-component", "test/component", "test_component"]
+    def test_middleware_response_with_components_with_slash_dash_and_underscore(
+        self,
+    ):
+        component_names = [
+            "test-component",
+            "test/component",
+            "test_component",
+        ]
         for component_name in component_names:
             component.registry.register(
                 name=component_name, component=SimpleComponent
@@ -412,8 +418,11 @@ class ComponentMediaRenderingTests(SimpleTestCase):
                 f"{{% component '{component_name}' variable='value' %}}"
             )
             rendered = create_and_process_template_response(template)
-            self.assertEqual((
-                '<script src="script.js"></script>'
-                '<link href="style.css" media="all" rel="stylesheet">'
-                "Variable: <strong>value</strong>\n"
-            ), rendered)
+            self.assertEqual(
+                (
+                    '<script src="script.js"></script>'
+                    '<link href="style.css" media="all" rel="stylesheet">'
+                    "Variable: <strong>value</strong>\n"
+                ),
+                rendered,
+            )

--- a/tests/test_dependency_rendering.py
+++ b/tests/test_dependency_rendering.py
@@ -419,10 +419,10 @@ class ComponentMediaRenderingTests(SimpleTestCase):
             )
             rendered = create_and_process_template_response(template)
             self.assertHTMLEqual(
+                rendered,
                 (
                     '<script src="script.js"></script>'
                     '<link href="style.css" media="all" rel="stylesheet">'
                     "Variable: <strong>value</strong>\n"
                 ),
-                rendered,
             )

--- a/tests/test_dependency_rendering.py
+++ b/tests/test_dependency_rendering.py
@@ -399,18 +399,21 @@ class ComponentMediaRenderingTests(SimpleTestCase):
         request = Mock()
         self.assertEqual(response, middleware(request=request))
 
-    def test_middleware_response_with_components_with_slash_and_dash(self):
-        component.registry.register(
-            name="test-component", component=SimpleComponent
-        )
-        component.registry.register(
-            name="test/component", component=SimpleComponent
-        )
-
-        template = Template(
-            "{% load component_tags %}{% component_js_dependencies %}"
-            "{% component 'test-component' variable='variable' %}"
-            "{% component 'test/component' variable='variable' %}"
-        )
-        rendered = create_and_process_template_response(template)
-        self.assertNotIn("_RENDERED", rendered)
+    def test_middleware_response_with_components_with_slash_dash_and_underscore(self):
+        component_names = ["test-component", "test/component", "test_component"]
+        for component_name in component_names:
+            component.registry.register(
+                name=component_name, component=SimpleComponent
+            )
+            template = Template(
+                "{% load component_tags %}"
+                "{% component_js_dependencies %}"
+                "{% component_css_dependencies %}"
+                f"{{% component '{component_name}' variable='value' %}}"
+            )
+            rendered = create_and_process_template_response(template)
+            self.assertEqual((
+                '<script src="script.js"></script>'
+                '<link href="style.css" media="all" rel="stylesheet">'
+                "Variable: <strong>value</strong>\n"
+            ), rendered)


### PR DESCRIPTION
- Fix the COMPONENT_COMMENT_REGEX to find component names with special symbols.
- Fix the test to catch the error.

Follow-up of e0c29e5 and ref: #262
