### PR TITLE
Fix for issue with django-compressor

### DIFF
--- a/django_components/templatetags/component_tags.py
+++ b/django_components/templatetags/component_tags.py
@@ -403,13 +403,13 @@ class ComponentNode(Node):
         self.context_kwargs = context_kwargs or {}
         self.isolated_context = isolated_context
         self.fill_nodes = fill_nodes
+        self.nodelist = self._create_nodelist(fill_nodes)
 
-    @property
-    def nodelist(self) -> Union[NodeList, Node]:
-        if isinstance(self.fill_nodes, ImplicitFillNode):
-            return NodeList([self.fill_nodes])
+    def _create_nodelist(self, fill_nodes) -> NodeList:
+        if isinstance(fill_nodes, ImplicitFillNode):
+            return NodeList([fill_nodes])
         else:
-            return NodeList(self.fill_nodes)
+            return NodeList(fill_nodes)
 
     def __repr__(self):
         return "<ComponentNode: %s. Contents: %r>" % (
@@ -749,13 +749,13 @@ class IfSlotFilledNode(Node):
         branches: List[_IfSlotFilledBranchNode],
     ):
         self.branches = branches
+        self.nodelist = self._create_nodelist(branches)
 
     def __repr__(self):
         return f"<{self.__class__.__name__}>"
 
-    @property
-    def nodelist(self):
-        return NodeList(self.branches)
+    def _create_nodelist(self, branches) -> NodeList:
+        return NodeList(branches)
 
     def render(self, context):
         for node in self.branches:


### PR DESCRIPTION
Hi @EmilStenstrom,

I was checking issue #300 and it looks like there's a quick fix.

There's a function called [handle_extendsnode](https://github.com/django-compressor/django-compressor/blob/939499ecca8886b3192da1343f20b30ab248baa4/compressor/offline/django.py#L20) in **django-compressor**, that creates a copy of the node tree replacing the block tags with the nodes of the children blocks.

During that process the `nodelist` is replaced [here](https://github.com/django-compressor/django-compressor/blob/939499ecca8886b3192da1343f20b30ab248baa4/compressor/offline/django.py#L84). But looks like those changes are compatible with **django-components**.

I did this small change, tested the results in an example provided by @spapas, and it looks like things are working well. Also, all tests are passing.

So I think it's safe to merge.

Best,
Dylan
