### PR TITLE
Fix issue #368 and add tests

### DIFF
--- a/django_components/component.py
+++ b/django_components/component.py
@@ -1,4 +1,5 @@
 import difflib
+import inspect
 from collections import ChainMap
 from typing import Any, ClassVar, Dict, Iterable, Optional, Set, Tuple, Union
 
@@ -90,7 +91,7 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
     @classmethod
     @property
     def class_hash(cls):
-        return hash(str(cls.__module__) + str(cls.__name__))
+        return hash(inspect.getfile(cls) + cls.__name__)
 
     def get_context_data(self, *args, **kwargs) -> Dict[str, Any]:
         return {}

--- a/django_components/component.py
+++ b/django_components/component.py
@@ -88,10 +88,8 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
         self.outer_context: Context = outer_context or Context()
         self.fill_content = fill_content
 
-    @classmethod
-    @property
-    def class_hash(cls):
-        return hash(inspect.getfile(cls) + cls.__name__)
+    def __init_subclass__(cls, **kwargs):
+        cls.class_hash = hash(inspect.getfile(cls) + cls.__name__)
 
     def get_context_data(self, *args, **kwargs) -> Dict[str, Any]:
         return {}

--- a/django_components/template_loader.py
+++ b/django_components/template_loader.py
@@ -12,17 +12,17 @@ from django.template.utils import get_app_template_dirs
 class Loader(FilesystemLoader):
     def get_dirs(self):
         component_dir = "components"
-        directories = list(get_app_template_dirs(component_dir))
+        directories = set(get_app_template_dirs(component_dir))
 
         if settings.SETTINGS_MODULE:
             settings_path = Path(*settings.SETTINGS_MODULE.split("."))
 
             path = (settings_path / ".." / component_dir).resolve()
             if path.is_dir():
-                directories.append(path)
+                directories.add(path)
 
             path = (settings_path / ".." / ".." / component_dir).resolve()
             if path.is_dir():
-                directories.append(path)
+                directories.add(path)
 
-        return directories
+        return list(directories)

--- a/sampleproject/components/calendar/calendar.py
+++ b/sampleproject/components/calendar/calendar.py
@@ -14,6 +14,12 @@ class Calendar(component.Component):
             "date": date,
         }
 
+    def get(self, request, *args, **kwargs):
+        context = {
+            "date": request.GET.get("date", ""),
+        }
+        return self.render_to_response(context)
+
     class Media:
         css = "calendar/calendar.css"
         js = "calendar/calendar.js"

--- a/sampleproject/components/urls.py
+++ b/sampleproject/components/urls.py
@@ -1,6 +1,8 @@
+from components.calendar.calendar import Calendar
+from components.greeting import Greeting
 from django.urls import path
-from greeting import Greeting
 
 urlpatterns = [
     path("greeting/", Greeting.as_view(), name="greeting"),
+    path("calendar/", Calendar.as_view(), name="calendar"),
 ]

--- a/tests/components/multi_file/multi_file.html
+++ b/tests/components/multi_file/multi_file.html
@@ -1,0 +1,5 @@
+<form method="post">
+  {% csrf_token %}
+  <input type="text" name="variable" value="{{ variable }}">
+  <input type="submit">
+</form>

--- a/tests/components/multi_file/multi_file.py
+++ b/tests/components/multi_file/multi_file.py
@@ -1,0 +1,20 @@
+from typing import Any, Dict
+
+from django.http import HttpResponse
+
+from django_components import component
+
+
+@component.register("multi_file_component")
+class MultFileComponent(component.Component):
+    template_name = "multi_file/multi_file.html"
+
+    def post(self, request, *args, **kwargs) -> HttpResponse:
+        variable = request.POST.get("variable")
+        return self.render_to_response({"variable": variable})
+
+    def get(self, request, *args, **kwargs) -> HttpResponse:
+        return self.render_to_response({"variable": "GET"})
+
+    def get_context_data(self, variable, *args, **kwargs) -> Dict[str, Any]:
+        return {"variable": variable}

--- a/tests/components/single_file.py
+++ b/tests/components/single_file.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict
+
+from django.http import HttpResponse
+
+from django_components import component
+
+
+@component.register("single_file_component")
+class SingleFileComponent(component.Component):
+    template = """
+        <form method="post">
+            {% csrf_token %}
+            <input type="text" name="variable" value="{{ variable }}">
+            <input type="submit">
+        </form>
+        """
+
+    def post(self, request, *args, **kwargs) -> HttpResponse:
+        variable = request.POST.get("variable")
+        return self.render_to_response({"variable": variable})
+
+    def get(self, request, *args, **kwargs) -> HttpResponse:
+        return self.render_to_response({"variable": "GET"})
+
+    def get_context_data(self, variable, *args, **kwargs) -> Dict[str, Any]:
+        return {"variable": variable}

--- a/tests/components/urls.py
+++ b/tests/components/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from tests.components.multi_file.multi_file import MultFileComponent
+from tests.components.single_file import SingleFileComponent
+
+urlpatterns = [
+    path("single/", SingleFileComponent.as_view(), name="single"),
+    path("multi/", MultFileComponent.as_view(), name="multi"),
+]

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -1,0 +1,30 @@
+from django.urls import include, path
+
+# isort: off
+from .django_test_setup import *  # noqa
+from .testutils import Django30CompatibleSimpleTestCase as SimpleTestCase
+
+# isort: on
+
+
+from django_components import autodiscover, component
+
+urlpatterns = [
+    path("", include("tests.components.urls")),
+]
+
+
+class TestAutodiscover(SimpleTestCase):
+    def setUp(self):
+        settings.SETTINGS_MODULE = "tests.test_autodiscover"  # noqa
+
+    def tearDown(self) -> None:
+        del settings.SETTINGS_MODULE  # noqa
+
+    def test_autodiscover_with_components_as_views(self):
+        try:
+            autodiscover()
+        except component.AlreadyRegistered:
+            self.fail(
+                "Autodiscover should not raise AlreadyRegistered exception"
+            )


### PR DESCRIPTION
Hey @EmilStenstrom @Fingel,

I got a working version of a fix for issue #368. There was a quick fix (but @EmilStenstrom you might not be its biggest fan 😅). The hardest part was getting tests that replicated the issue, but I now have a version that seems to achieve that.

@Fingel your research was very useful to understand where the issue originated. Thank you very much.

When Django [initializes](https://docs.djangoproject.com/en/5.0/ref/applications/#initialization-process) the application registry, for each application in `INSTALLED_APPS` Django imports the root package of the application.

For `django-components`, this means the `ready` method is called which then calls `autodiscover`, as pointed by Fingel. `autodiscover` looks for all the locations of components and then executes those files.

The issue occurs during the execution of the component files found in `autodiscover`, specifically in `spec.loader.exec_module(module)`. Due to differences in the way the modules are imported I couldn't find a way to verify if two components were the same except for checking the file it was coming from + the name of the class.

I found two ways to do that:

1. `sys.modules[cls.__module__].__file__`: I think this should always work, but I'm not really sure, I have some gaps on how some of the `spec` and `module` stuff works. So, I'd rather go for a less standard approach, but one that I feel more confident about.
2. `inspect.getfile(cls)`: This is the method I proposed previously. Based on my tests it works well, and even though it might seem a bit hacky, other projects such as spaCy seem to use it for [similar purposes](https://github.com/explosion/spaCy/blob/a493981163002d0cd2409950512eeeccb6fa4690/spacy/util.py#L1143).

I propose we use `inspect.getfile()` fix for now. I think it's worth it, given the use cases it unblocks. OTOH, for future releases (including some of the stuff we were discussing in the HTMX-enabled components thread), it might be worthwhile to rethink the whole registration process, given that Components are becoming more complex now.

Also, I found an unrelated issue in `autodiscover` that, depending on the path resolution, resulted in duplicated directories when running `Loader.get_dirs`. This wasn't causing this issue, but I fixed it as well (see changes to `template_loader.py`. Maybe it'd speed up a bit the initialization process.

Finally, after some research, I realized that there's [no guarantee](https://docs.djangoproject.com/en/5.0/ref/applications/#django.apps.AppConfig.ready) that `ready` will be called only once when initializing the application. So, `autodiscover` and thus the registry of components must be robust to be running them multiple times. At first, I thought that we could prevent `autodiscover` from running twice, but I don't think that makes a lot of sense based on this new information.

TL;DR:

1. I propose we use `inspect.getfile()` as it fixes the issue for now.
2. I got tests that replicate the issue.
3. I also found a smaller bug I fixed in `template_loader.py`
4. For future releases it might be worthwhile to rethink the whole registration process
