### PR TITLE
Don't rely on BASE_DIR being a Path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Modify STATICFILES_DIRS (or add it if you don't have it) so django can find your
 ```python
 STATICFILES_DIRS = [
     ...,
-    BASE_DIR / "components",
+    os.path.join(BASE_DIR, "components"),
 ]
 ```
 

--- a/django_components/template_loader.py
+++ b/django_components/template_loader.py
@@ -15,7 +15,7 @@ class Loader(FilesystemLoader):
         directories = set(get_app_template_dirs(component_dir))
 
         if hasattr(settings, "BASE_DIR"):
-            path = (settings.BASE_DIR / component_dir).resolve()
+            path = (Path(settings.BASE_DIR) / component_dir).resolve()
             if path.is_dir():
                 directories.add(path)
 


### PR DESCRIPTION
Fixes #381

I went through all usages of BASE_DIR in the project and made sure all of them are safe for strings. Didn't touch sampleproject which still defined BASE_DIR as a Path.