### PR TITLE
fix: type component registry

### DIFF
--- a/django_components/component.py
+++ b/django_components/component.py
@@ -164,6 +164,7 @@ def _get_dir_path_from_component_module_path(component_module_path: str, candida
 class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
     # Either template_name or template must be set on subclass OR subclass must implement get_template() with
     # non-null return.
+    class_hash: ClassVar[int]
     template_name: ClassVar[Optional[str]] = None
     template: Optional[str] = None
     js: Optional[str] = None

--- a/django_components/component_registry.py
+++ b/django_components/component_registry.py
@@ -10,7 +10,7 @@ class AlreadyRegistered(Exception):
     pass
 
 
-class NotRegistered(Exception) :
+class NotRegistered(Exception):
     pass
 
 

--- a/django_components/component_registry.py
+++ b/django_components/component_registry.py
@@ -1,44 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Type, TypeVar
+
+if TYPE_CHECKING:
+    from django_components import component
+
+_TC = TypeVar("_TC", bound=Type["component.Component"])
+
+
 class AlreadyRegistered(Exception):
     pass
 
 
-class NotRegistered(Exception):
+class NotRegistered(Exception) :
     pass
 
 
-class ComponentRegistry(object):
-    def __init__(self):
-        self._registry = {}  # component name -> component_class mapping
+class ComponentRegistry:
+    def __init__(self) -> None:
+        self._registry: dict[str, type[component.Component]] = {}  # component name -> component_class mapping
 
-    def register(self, name=None, component=None):
+    def register(self, name: str, component: type[component.Component]) -> None:
         existing_component = self._registry.get(name)
         if existing_component and existing_component.class_hash != component.class_hash:
             raise AlreadyRegistered('The component "%s" has already been registered' % name)
         self._registry[name] = component
 
-    def unregister(self, name):
+    def unregister(self, name: str) -> None:
         self.get(name)
 
         del self._registry[name]
 
-    def get(self, name):
+    def get(self, name: str) -> type[component.Component]:
         if name not in self._registry:
             raise NotRegistered('The component "%s" is not registered' % name)
 
         return self._registry[name]
 
-    def all(self):
+    def all(self) -> dict[str, type[component.Component]]:
         return self._registry
 
-    def clear(self):
+    def clear(self) -> None:
         self._registry = {}
 
 
 # This variable represents the global component registry
-registry = ComponentRegistry()
+registry: ComponentRegistry = ComponentRegistry()
 
 
-def register(name):
+def register(name: str) -> Callable[[_TC], _TC]:
     """Class decorator to register a component.
 
     Usage:
@@ -48,7 +58,7 @@ def register(name):
         ...
     """
 
-    def decorator(component):
+    def decorator(component: _TC) -> _TC:
         registry.register(name=name, component=component)
         return component
 

--- a/django_components/component_registry.py
+++ b/django_components/component_registry.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Callable, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Dict, Type, TypeVar
 
 if TYPE_CHECKING:
     from django_components import component
@@ -18,9 +16,9 @@ class NotRegistered(Exception) :
 
 class ComponentRegistry:
     def __init__(self) -> None:
-        self._registry: dict[str, type[component.Component]] = {}  # component name -> component_class mapping
+        self._registry: Dict[str, Type["component.Component"]] = {}  # component name -> component_class mapping
 
-    def register(self, name: str, component: type[component.Component]) -> None:
+    def register(self, name: str, component: Type["component.Component"]) -> None:
         existing_component = self._registry.get(name)
         if existing_component and existing_component.class_hash != component.class_hash:
             raise AlreadyRegistered('The component "%s" has already been registered' % name)
@@ -31,13 +29,13 @@ class ComponentRegistry:
 
         del self._registry[name]
 
-    def get(self, name: str) -> type[component.Component]:
+    def get(self, name: str) -> Type["component.Component"]:
         if name not in self._registry:
             raise NotRegistered('The component "%s" is not registered' % name)
 
         return self._registry[name]
 
-    def all(self) -> dict[str, type[component.Component]]:
+    def all(self) -> Dict[str, Type["component.Component"]]:
         return self._registry
 
     def clear(self) -> None:


### PR DESCRIPTION
Hey :wave:

I noticed in my project that mypy (in strict mode) was complaining that the `@component.register` decorator was untyped:
```
Call to untyped function "register" in typed context  [no-untyped-call]
```

I went ahead and typed the decorator, as well as the rest of the `component_registry` module.

I can scale back the changes to only type the decorator if needed.

Please let met know if you'd be interested in some help for the package, notably around type hints, CI or packaging, I'd be happy to contribute.

Thanks!