### PR TITLE
fix: avoid nested django contexts when rendering

### DIFF
--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -270,8 +270,11 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
         if slots_data:
             self._fill_slots(slots_data, escape_slots_content)
 
-        updated_filled_slots_context: FilledSlotsContext = self._process_template_and_update_filled_slot_context(
-            context, template
+        prev_filled_slots_context: Optional[FilledSlotsContext] = context.get(
+            FILLED_SLOTS_CONTENT_CONTEXT_KEY
+        )
+        updated_filled_slots_context = self._process_template_and_update_filled_slot_context(
+            template, prev_filled_slots_context, 
         )
         with context.update({FILLED_SLOTS_CONTENT_CONTEXT_KEY: updated_filled_slots_context}):
             return template.render(context)
@@ -307,8 +310,8 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
 
     def _process_template_and_update_filled_slot_context(
         self,
-        context: Context,
         template: Template,
+        slots_context: Optional[FilledSlotsContext],
     ) -> FilledSlotsContext:
         if isinstance(self.fill_content, NodeList):
             default_fill_content = (self.fill_content, None)
@@ -403,8 +406,7 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
             for slot_name, content_data in slot_name2fill_content.items()
             if content_data  # Slots whose content is None (i.e. unfilled) are dropped.
         }
-        try:
-            prev_context: FilledSlotsContext = context[FILLED_SLOTS_CONTENT_CONTEXT_KEY]
-            return prev_context.new_child(filled_slots_map)
-        except KeyError:
+        if slots_context is not None:
+            return slots_context.new_child(filled_slots_map)
+        else:
             return ChainMap(filled_slots_map)

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -270,11 +270,10 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
         if slots_data:
             self._fill_slots(slots_data, escape_slots_content)
 
-        prev_filled_slots_context: Optional[FilledSlotsContext] = context.get(
-            FILLED_SLOTS_CONTENT_CONTEXT_KEY
-        )
+        prev_filled_slots_context: Optional[FilledSlotsContext] = context.get(FILLED_SLOTS_CONTENT_CONTEXT_KEY)
         updated_filled_slots_context = self._process_template_and_update_filled_slot_context(
-            template, prev_filled_slots_context, 
+            template,
+            prev_filled_slots_context,
         )
         with context.update({FILLED_SLOTS_CONTENT_CONTEXT_KEY: updated_filled_slots_context}):
             return template.render(context)

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -262,7 +262,9 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
         slots_data: Optional[Dict[SlotName, str]] = None,
         escape_slots_content: bool = True,
     ) -> str:
-        context = Context(context_data)
+        # NOTE: This if/else is important to avoid nested Contexts,
+        # See https://github.com/EmilStenstrom/django-components/issues/414
+        context = context_data if isinstance(context_data, Context) else Context(context_data)
         template = self.get_template(context)
 
         if slots_data:


### PR DESCRIPTION
Closes https://github.com/EmilStenstrom/django-components/issues/414

The issue was with Context, turns out that the context_data in component.Component.render may already be an instance of Context, so a simple check for that fixed it for me.

I also updated the input for `_process_template_and_update_filled_slot_context`, so we're not passing in Django's Context, since it wasn't necessary, so there's less touchpoints with it.