### PR TITLE
build: move to PEP517 and pyproject.toml, drop support for Py3.6 and Py3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ Django-components supports all <a href="https://docs.djangoproject.com/en/dev/fa
 
 | Python version | Django version           |
 |----------------|--------------------------|
-| 3.6            | 3.2                      |
 | 3.7            | 3.2                      |
 | 3.8            | 3.2, 4.0, 4.1, 4.2       |
 | 3.9            | 3.2, 4.0, 4.1, 4.2       |
@@ -255,7 +254,7 @@ Components can also be defined in a single file, which is useful for small compo
 ```python
 # In a file called [project root]/components/calendar.py
 from django_components import component
-from django_components import types as t 
+from django_components import types as t
 
 @component.register("calendar")
 class Calendar(component.Component):
@@ -263,16 +262,16 @@ class Calendar(component.Component):
         return {
             "date": date,
         }
-    
+
     template: t.django_html = """
         <div class="calendar-component">Today's date is <span>{{ date }}</span></div>
     """
-    
+
     css: t.css = """
         .calendar-component { width: 200px; background: pink; }
         .calendar-component span { font-weight: bold; }
     """
-    
+
     js: t.js = """
         (function(){
             if (document.querySelector(".calendar-component")) {
@@ -284,7 +283,7 @@ class Calendar(component.Component):
 
 This makes it easy to create small components without having to create a separate template, CSS, and JS file.
 
-Note that the `t.django_html`, `t.css`, and `t.js` types are used to specify the type of the template, CSS, and JS files, respectively. This is not necessary, but if you're using VSCode with the [Python Inline Source Syntax Highlighting](https://marketplace.visualstudio.com/items?itemName=samwillis.python-inline-source) extension, it will give you syntax highlighting for the template, CSS, and JS. 
+Note that the `t.django_html`, `t.css`, and `t.js` types are used to specify the type of the template, CSS, and JS files, respectively. This is not necessary, but if you're using VSCode with the [Python Inline Source Syntax Highlighting](https://marketplace.visualstudio.com/items?itemName=samwillis.python-inline-source) extension, it will give you syntax highlighting for the template, CSS, and JS.
 
 ## Using slots in templates
 
@@ -416,7 +415,7 @@ This is fine too:
 
 _New in version 0.34_
 
-Components can now be used as views. To do this, `Component` subclasses Django's `View` class. This means that you can use all of the [methods](https://docs.djangoproject.com/en/5.0/ref/class-based-views/base/#view) of `View` in your component. For example, you can override `get` and `post` to handle GET and POST requests, respectively. 
+Components can now be used as views. To do this, `Component` subclasses Django's `View` class. This means that you can use all of the [methods](https://docs.djangoproject.com/en/5.0/ref/class-based-views/base/#view) of `View` in your component. For example, you can override `get` and `post` to handle GET and POST requests, respectively.
 
 In addition, `Component` now has a `render_to_response` method that renders the component template based on the provided context and slots' data and returns an `HttpResponse` object.
 
@@ -428,7 +427,7 @@ from django_components import component
 
 @component.register("calendar")
 class Calendar(component.Component):
-    
+
     template = """
         <div class="calendar-component">
             <div class="header">
@@ -439,7 +438,7 @@ class Calendar(component.Component):
             </div>
         </div>
     """
-    
+
     def get(self, request, *args, **kwargs):
         context = {
             "date": request.GET.get("date", "2020-06-06"),
@@ -455,7 +454,7 @@ Then, to use this component as a view, you should create a `urls.py` file in you
 ```python
 # In a file called [project root]/components/urls.py
 from django.urls import path
-from calendar import Calendar 
+from calendar import Calendar
 
 urlpatterns = [
     path("calendar/", Calendar.as_view()),
@@ -817,7 +816,6 @@ pytest
 The library is also tested across many versions of Python and Django. To run tests that way:
 
 ```sh
-pyenv install -s 3.6
 pyenv install -s 3.7
 pyenv install -s 3.8
 pyenv install -s 3.9

--- a/README.md
+++ b/README.md
@@ -138,11 +138,10 @@ Read on to find out how to build your first component!
 
 ## Compatiblity
 
-Django-components supports all <a href="https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django">officially supported versions</a> of Django and Python.
+Django-components supports all supported combinations versions of [Django](https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django) and [Python](https://devguide.python.org/versions/#versions).
 
 | Python version | Django version           |
 |----------------|--------------------------|
-| 3.7            | 3.2                      |
 | 3.8            | 3.2, 4.0, 4.1, 4.2       |
 | 3.9            | 3.2, 4.0, 4.1, 4.2       |
 | 3.10           | 3.2, 4.0, 4.1, 4.2, 5.0  |

--- a/README.md
+++ b/README.md
@@ -815,13 +815,12 @@ pytest
 The library is also tested across many versions of Python and Django. To run tests that way:
 
 ```sh
-pyenv install -s 3.7
 pyenv install -s 3.8
 pyenv install -s 3.9
 pyenv install -s 3.10
 pyenv install -s 3.11
 pyenv install -s 3.12
-pyenv local 3.6 3.7 3.8 3.9 3.10 3.11 3.12
+pyenv local 3.8 3.9 3.10 3.11 3.12
 tox -p
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "django_components"
 version = "0.63"
-requires-python = ">=3.6, <4.0"
+requires-python = ">=3.7, <4.0"
 description = "A way to create simple reusable template components in Django."
 keywords = ["django", "components", "css", "js", "html"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,49 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "django_components"
+version = "0.63"
+requires-python = ">=3.6, <4.0"
+description = "A way to create simple reusable template components in Django."
+keywords = ["django", "components", "css", "js", "html"]
+readme = "README.md"
+authors = [
+    {name = "Emil Stenström", email = "emil@emilstenstrom.se"},
+]
+classifiers = [
+    "Framework :: Django",
+    "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+]
+dependencies = [
+    'Django>=3.2',
+]
+license = {text = "MIT"}
+
+[project.urls]
+Homepage = "https://github.com/EmilStenstrom/django-components/"
+
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["django_components*"]
+exclude = ["django_components.tests*"]
+namespaces = false
+
 [tool.black]
 line-length = 119
 include = '\.pyi?$'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
     'Django>=3.2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "django_components"
 version = "0.63"
-requires-python = ">=3.7, <4.0"
+requires-python = ">=3.8, <4.0"
 description = "A way to create simple reusable template components in Django."
 keywords = ["django", "components", "css", "js", "html"]
 readme = "README.md"
@@ -25,7 +25,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
 ]

--- a/scripts/supported_versions.py
+++ b/scripts/supported_versions.py
@@ -200,7 +200,7 @@ def main():
     print()
     print()
 
-    print("Add this to setup.py:\n")
+    print("Add this to pyproject.toml:\n")
     pypi_classifiers = build_pypi_classifiers(python_to_django)
     print(pypi_classifiers)
     print()

--- a/scripts/supported_versions.py
+++ b/scripts/supported_versions.py
@@ -192,7 +192,7 @@ def build_pyenv(python_to_django: VersionMapping):
 
 
 def build_ci_python_versions(python_to_django: Dict[str, str]):
-    # Outputs python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+    # Outputs python-version, like: ['3.8', '3.9', '3.10', '3.11', '3.12']
     lines = [
         f"'{env_format(python_version, divider='.')}'" for python_version, django_versions in python_to_django.items()
     ]

--- a/scripts/supported_versions.py
+++ b/scripts/supported_versions.py
@@ -169,7 +169,7 @@ def build_pyenv(python_to_django: VersionMapping):
 
 
 def build_ci_python_versions(python_to_django: Dict[str, str]):
-    # Outputs python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+    # Outputs python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     lines = [
         f"'{env_format(python_version, divider='.')}'" for python_version, django_versions in python_to_django.items()
     ]
@@ -182,6 +182,9 @@ def main():
     latest_version = get_latest_version("https://www.djangoproject.com/download/")
 
     python_to_django = build_python_to_django(django_to_python, latest_version)
+
+    # Force drop support for 3.6
+    python_to_django.pop((3, 6), None)
 
     tox_envlist = build_tox_envlist(python_to_django)
     print("Add this to tox.ini:\n")

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,6 @@
-# -*- coding: utf-8 -*-
-import os
+# Configuration has moved to pyproject.toml
+# This file is maintained for backward compatibility
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
-VERSION = "0.63"
-
-setup(
-    name="django_components",
-    packages=find_packages(where="src", exclude=["tests", "tests.*"]),
-    package_dir={"": "src"},
-    package_data={
-        "django_components": ["py.typed"],
-    },
-    version=VERSION,
-    description="A way to create simple reusable template components in Django.",
-    long_description=open(os.path.join(os.path.dirname(__file__), "README.md"), encoding="utf8").read(),
-    long_description_content_type="text/markdown",
-    author="Emil Stenström",
-    author_email="emil@emilstenstrom.se",
-    url="https://github.com/EmilStenstrom/django-components/",
-    install_requires=["Django>=3.2"],
-    license="MIT",
-    keywords=["django", "components", "css", "js", "html"],
-    classifiers=[
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
-        "Framework :: Django :: 4.1",
-        "Framework :: Django :: 4.2",
-        "Framework :: Django :: 5.0",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Operating System :: OS Independent",
-        "Framework :: Django",
-    ],
-)
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-# Configuration has moved to pyproject.toml
-# This file is maintained for backward compatibility
-
-from setuptools import setup
-
-setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
-# This library strives to support the same versions of django and python that django supports:
+# This library strives to support all officially supported combinations of Python and Django:
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
+# https://devguide.python.org/versions/#versions
 
 [tox]
 envlist =
-  py37-django{32}
   py38-django{32,40,41,42}
   py39-django{32,40,41,42}
   py310-django{32,40,41,42,50}
@@ -16,7 +16,6 @@ envlist =
 
 [gh-actions]
 python =
-  3.7: py37-django{32}
   3.8: py38-django{32,40,41,42}
   3.9: py39-django{32,40,41,42}
   3.10: py310-django{32,40,41,42,50}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@
 
 [tox]
 envlist =
-  py36-django{32}
   py37-django{32}
   py38-django{32,40,41,42}
   py39-django{32,40,41,42}
@@ -14,13 +13,9 @@ envlist =
   isort
   coverage
   mypy
-requires = virtualenv<20.22.0
-
-# https://tox.wiki/en/latest/faq.html#testing-end-of-life-python-versions
 
 [gh-actions]
 python =
-  3.6: py36-django{32}
   3.7: py37-django{32}
   3.8: py38-django{32,40,41,42}
   3.9: py39-django{32,40,41,42}


### PR DESCRIPTION
Hey :wave: 

Following the recent packaging changes, I propose to go a step further and move to pyproject.toml, to use more modern Python packaging tooling.

This change will enable us to use any modern build-system, like recent `setuptools`, `pdm-backend` `hatchling`, which supports plugins. This could be useful to set the version automatically from the Git tag for example.

Unfortunately, Python 3.6 being no longer supported, I had to drop its support. I opened an issue #418 to discuss Python support policy.