### PR TITLE
fix: remove components from global scope module

### DIFF
--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -1,6 +1,5 @@
 import importlib
 import importlib.util
-import sys
 from pathlib import Path
 from typing import Union
 
@@ -36,5 +35,4 @@ def import_file(path: Union[str, Path]) -> None:
     if spec is None:
         raise ValueError(f"Cannot import file '{path}' - invalid path")
     module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
     spec.loader.exec_module(module)  # type: ignore

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -1,4 +1,3 @@
-import inspect
 import os
 import sys
 from pathlib import Path
@@ -193,7 +192,7 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
         self.fill_content = fill_content
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
-        cls.class_hash = hash(inspect.getfile(cls) + cls.__name__)
+        cls.class_hash = hash(os.path.abspath(__file__) + cls.__name__)
 
     def get_context_data(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
         return {}


### PR DESCRIPTION
fixes #431 

- removed module name registering from global scope
- changed the way components are hashed so it doesn't depend on the global scope module name