### PR TITLE
fix: make template_loader consider tuples for STATICFILES_DIRS

### DIFF
--- a/src/django_components/template_loader.py
+++ b/src/django_components/template_loader.py
@@ -37,7 +37,7 @@ class Loader(FilesystemLoader):
 
         directories: Set[Path] = set()
         for component_dir in component_dirs:
-            if isinstance(component_dir, tuple | list) and len(component_dir) == 2:
+            if isinstance(component_dir, (tuple, list)) and len(component_dir) == 2:
                 component_dir = component_dir[1]
             try:
                 Path(component_dir)

--- a/src/django_components/template_loader.py
+++ b/src/django_components/template_loader.py
@@ -37,6 +37,16 @@ class Loader(FilesystemLoader):
 
         directories: Set[Path] = set()
         for component_dir in component_dirs:
+            if isinstance(component_dir, tuple | list) and len(component_dir) == 2:
+                component_dir = component_dir[1]
+            try:
+                Path(component_dir)
+            except TypeError:
+                logger.warning(
+                    f"STATICFILES_DIRS expected str, bytes or os.PathLike object, or tuple/list of length 2. "
+                    f"See Django documentation. Got {type(component_dir)} : {component_dir}"
+                )
+                continue
             curr_directories: Set[Path] = set()
 
             # For each dir in `settings.STATICFILES_DIRS`, we go over all Django apps

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -138,7 +138,7 @@ class TestStaticFilesDirs(BaseTestCase):
     def tearDown(self) -> None:
         del settings.STATICFILES_DIRS  # noqa
 
-    @patch("django_components.logger.logger.warning")
+    @patch("django_components.template_loader.logger.warning")
     def test_static_files_dirs(self, mock_warning: MagicMock):
         mock_warning.reset_mock()
         current_engine = Engine.get_default()

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 from django.template.engine import Engine
 from django.urls import include, path
@@ -123,6 +124,29 @@ class TestBaseDir(BaseTestCase):
             Path(__file__).parent.resolve() / "test_structures" / "test_structure_1" / "components",
         ]
         self.assertEqual(sorted(dirs), sorted(expected))
+
+
+class TestStaticFilesDirs(BaseTestCase):
+    def setUp(self):
+        settings.STATICFILES_DIRS = [
+            "components",
+            ("with_alias", "components"),
+            ("too_many", "items", "components"),
+            ("with_not_str_alias", 3),
+        ]  # noqa
+
+    def tearDown(self) -> None:
+        del settings.STATICFILES_DIRS  # noqa
+
+    @patch("django_components.logger.logger.warning")
+    def test_static_files_dirs(self, mock_warning: MagicMock):
+        mock_warning.reset_mock()
+        current_engine = Engine.get_default()
+        Loader(current_engine).get_dirs()
+
+        warn_inputs = [warn.args[0] for warn in mock_warning.call_args_list]
+        assert "Got <class 'tuple'> : ('too_many', 'items', 'components')" in warn_inputs[0]
+        assert "Got <class 'int'> : 3" in warn_inputs[1]
 
 
 class TestFilepathToPythonModule(BaseTestCase):


### PR DESCRIPTION
fixes #476  

Hoping to fix issue [here](https://github.com/EmilStenstrom/django-components/issues/476)

I suggested to use `logger.warning` and simply not to consider the _STATICFILES_DIR_ value if the value is incorrect. But depends on your preference.