### PR TITLE
feat: alias component_registry imports for mypy

### DIFF
--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -19,8 +19,11 @@ from django.views import View
 # Defining them here made little sense, since 1) component_tags.py and component.py
 # rely on them equally, and 2) it made it difficult to avoid circularity in the
 # way the two modules depend on one another.
+from django_components.component_registry import AlreadyRegistered as AlreadyRegistered  # NOQA
+from django_components.component_registry import ComponentRegistry as ComponentRegistry  # NOQA
+from django_components.component_registry import NotRegistered as NotRegistered  # NOQA
+from django_components.component_registry import register as register  # NOQA
 from django_components.component_registry import registry  # NOQA
-from django_components.component_registry import AlreadyRegistered, ComponentRegistry, NotRegistered, register  # NOQA
 from django_components.context import (
     _FILLED_SLOTS_CONTENT_CONTEXT_KEY,
     _PARENT_COMP_CONTEXT_KEY,


### PR DESCRIPTION
### Resolving issue:
- https://github.com/EmilStenstrom/django-components/issues/458

As asked by @EmilStenstrom I'm making this small contribution

#### Full mypy error message:
```
"register" is not exported from module "django_components.component" [reportPrivateImportUsage] 
```

--- 
Tested also output in `pyright` lsp and it is happy too:
Before:
![image](https://github.com/EmilStenstrom/django-components/assets/37776903/fa309bed-8277-4b24-bd3d-83386820dafb)

After:
![image](https://github.com/EmilStenstrom/django-components/assets/37776903/df061f9c-5563-4020-a307-ef04af42072f)


