### PR TITLE
fix: typo in html_attrs defaults dict fetching

### DIFF
--- a/src/django_components/attributes.py
+++ b/src/django_components/attributes.py
@@ -55,7 +55,7 @@ class HtmlAttrsNode(Node):
 
         # NOTE: We want to allow to use `html_attrs` even without `attrs` or `defaults` params
         attrs = attrs_and_defaults_from_kwargs.get("attrs", {})
-        default_attrs = attrs_and_defaults_from_kwargs.get("defualts", {})
+        default_attrs = attrs_and_defaults_from_kwargs.get("defaults", {})
 
         final_attrs = {**default_attrs, **attrs}
         final_attrs = append_attributes(*final_attrs.items(), *append_attrs)

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -274,12 +274,11 @@ class HtmlAttrsTests(BaseTestCase):
         self.assertHTMLEqual(
             rendered,
             """
-            <div class="added_class another-class" data-id=123>
+            <div class="added_class another-class override-me" data-id=123>
                 content
             </div>
             """,
         )
-        self.assertNotIn("override-me", rendered)
 
     def test_tag_no_defaults(self):
         @component.register("test")


### PR DESCRIPTION
Addresses this issue: https://github.com/EmilStenstrom/django-components/issues/512