### PR TITLE
refactor: change context_behavior default to "django"

### DIFF
--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -105,7 +105,7 @@ class AppSettings:
 
     @property
     def CONTEXT_BEHAVIOR(self) -> ContextBehavior:
-        raw_value = self.settings.get("context_behavior", ContextBehavior.ISOLATED.value)
+        raw_value = self.settings.get("context_behavior", ContextBehavior.DJANGO.value)
         return self._validate_context_behavior(raw_value)
 
     def _validate_context_behavior(self, raw_value: ContextBehavior) -> ContextBehavior:


### PR DESCRIPTION
Change the default `context_behavior` setting to "django", and update README.

Closes https://github.com/EmilStenstrom/django-components/issues/498