### PR TITLE
feat: refactor render fn and allow slots as functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Read on to learn about the details!
 
 ## Release notes
 
+🚨📢 **Version 0.81** Aligned the `render_to_response` method with the (now public) `render` method of `Component` class. Moreover, slots passed to these can now be rendered also as functions.
+
+- BREAKING CHANGE: The order of arguments to `render_to_response` has changed.
+
 **Version 0.80** introduces dependency injection with the `{% provide %}` tag and `inject()` method.
 
 🚨📢 **Version 0.79**
@@ -313,7 +317,7 @@ This makes it easy to create small components without having to create a separat
 
 Note that the `t.django_html`, `t.css`, and `t.js` types are used to specify the type of the template, CSS, and JS files, respectively. This is not necessary, but if you're using VSCode with the [Python Inline Source Syntax Highlighting](https://marketplace.visualstudio.com/items?itemName=samwillis.python-inline-source) extension, it will give you syntax highlighting for the template, CSS, and JS.
 
-## Use the component in a template
+## Use components in templates
 
 First load the `component_tags` tag library, then use the `component_[js/css]_dependencies` and `component` tags to render the component to the page.
 
@@ -358,13 +362,143 @@ The output from the above template will be:
 
 This makes it possible to organize your front-end around reusable components. Instead of relying on template tags and keeping your CSS and Javascript in the static directory.
 
+## Use components outside of templates
+
+_New in version 0.81_
+
+Components can be rendered outside of Django templates, calling them as regular functions ("React-style").
+
+The component class defines `render` and `render_to_response` class methods. These methods accept positional args, kwargs, and slots, offering the same flexibility as the `{% component %}` tag:
+
+```py
+class SimpleComponent(component.Component):
+    template = """
+        {% load component_tags %}
+        hello: {{ hello }}
+        foo: {{ foo }}
+        kwargs: {{ kwargs|safe }}
+        slot_first: {% slot "first" required %}{% endslot %}
+    """
+
+    def get_context_data(self, arg1, arg2, **kwargs):
+        return {
+            "hello": arg1,
+            "foo": arg2,
+            "kwargs": kwargs,
+        }
+
+rendered = SimpleComponent.render(
+    args=["world", "bar"],
+    kwargs={"kw1": "test", "kw2": "ooo"},
+    slots={"first": "FIRST_SLOT"},
+    context={"from_context": 98},
+)
+```
+
+Renders:
+
+```
+hello: world
+foo: bar
+kwargs: {'kw1': 'test', 'kw2': 'ooo'}
+slot_first: FIRST_SLOT
+```
+
+### Inputs of `render` and `render_to_response`
+
+Both `render` and `render_to_response` accept the same input:
+
+```py
+Component.render(
+    context: Mapping | django.template.Context | None = None,
+    args: List[Any] | None = None,
+    kwargs: Dict[str, Any] | None = None,
+    slots: Dict[str, str | SafeString | SlotRenderFunc] | None = None,
+    escape_slots_content: bool = True
+) -> str:
+```
+
+- _`args`_ - Positional args for the component. This is the same as calling the component
+   as `{% component "my_comp" arg1 arg2 ... %}`
+
+- _`kwargs`_ - Keyword args for the component. This is the same as calling the component
+   as `{% component "my_comp" key1=val1 key2=val2 ... %}`
+
+- _`slots`_ - Component slot fills. This is the same as pasing `{% fill %}` tags to the component.
+   Accepts a dictionary of `{ slot_name: slot_content }` where `slot_content` can be a string
+   or [`SlotRenderFunc`](#slotrenderfunc).
+
+- _`escape_slots_content`_ - Whether the content from `slots` should be escaped. `True` by default to prevent XSS attacks. If you disable escaping, you should make sure that any content you pass to the slots is safe, especially if it comes from user input.
+
+- _`context`_ - A context (dictionary or Django's Context) within which the component
+   is rendered. The keys on the context can be accessed from within the template.
+   - NOTE: In "isolated" mode, context is NOT accessible, and data MUST be passed via
+      component's args and kwargs.
+
+#### `SlotRenderFunc`
+
+When rendering components with slots in `render` or `render_to_response`, you can pass either a string or a function.
+
+The function has following signature:
+
+```py
+def render_func(
+   context: Context,
+   data: Dict[str, Any],
+   slot_ref: SlotRef,
+) -> str | SafeString:
+    return nodelist.render(ctx)
+```
+
+- _`context`_ - Django's Context available to the Slot Node.
+- _`data`_ - Data passed to the `{% slot %}` tag. See [Scoped Slots](#scoped-slots).
+- _`slot_ref`_ - The default slot content. See [Accessing original content of slots](#accessing-original-content-of-slots).
+   - NOTE: The slot is lazily evaluated. To render the slot, convert it to string with `str(slot_ref)`.
+
+Example:
+```py
+def footer_slot(ctx, data, slot_ref):
+   return f"""
+      SLOT_DATA: {data['abc']}
+      ORIGINAL: {slot_ref}
+   """
+
+MyComponent.render_to_response(
+    slots={
+        "footer": footer_slot,
+   },
+)
+```
+
+### Response class of `render_to_response`
+
+While `render` method returns a plain string, `render_to_response` wraps the rendered content in a "Response" class. By default, this is `django.http.HttpResponse`.
+
+If you want to use a different Response class in `render_to_response`, set the `Component.response_class` attribute:
+
+```py
+class MyResponse(HttpResponse):
+   def __init__(self, *args, **kwargs) -> None:
+      super().__init__(*args, **kwargs)
+      # Configure response
+      self.headers = ...
+      self.status = ...
+
+class SimpleComponent(component.Component):
+   response_class = MyResponse
+   template: types.django_html = "HELLO"
+
+response = SimpleComponent.render_to_response()
+assert isinstance(response, MyResponse)
+```
+
 ## Use components as views
 
 _New in version 0.34_
 
 Components can now be used as views. To do this, `Component` subclasses Django's `View` class. This means that you can use all of the [methods](https://docs.djangoproject.com/en/5.0/ref/class-based-views/base/#view) of `View` in your component. For example, you can override `get` and `post` to handle GET and POST requests, respectively.
 
-In addition, `Component` now has a `render_to_response` method that renders the component template based on the provided context and slots' data and returns an `HttpResponse` object.
+In addition, `Component` now has a [`render_to_response`](#inputs-of-render-and-render_to_response) method that renders the component template based on the provided context and slots' data and returns an `HttpResponse` object.
 
 Here's an example of a calendar component defined as a view:
 
@@ -393,7 +527,7 @@ class Calendar(component.Component):
         slots = {
             "header": "Calendar header",
         }
-        return self.render_to_response(context, slots)
+        return self.render_to_response(context=context, slots=slots)
 ```
 
 Then, to use this component as a view, you should create a `urls.py` file in your components directory, and add a path to the component's view:

--- a/sampleproject/components/greeting.py
+++ b/sampleproject/components/greeting.py
@@ -9,7 +9,7 @@ class Greeting(component.Component):
     def get(self, request, *args, **kwargs):
         slots = {"message": "Hello, world!"}
         context = {"name": request.GET.get("name", "")}
-        return self.render_to_response(context, slots)
+        return self.render_to_response(context=context, slots=slots)
 
     def get_context_data(self, name, *args, **kwargs) -> Dict[str, Any]:
         return {"name": name}

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -348,21 +348,45 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
         **response_kwargs: Any,
     ) -> HttpResponse:
         """
+        Render the component and wrap the content in the response class.
+
+        The response class is taken from `Component.response_class`. Defaults to `django.http.HttpResponse`.
+
         This is the interface for the `django.views.View` class which allows us to
         use components as Django views with `component.as_view()`.
+
+        Inputs:
+        - `args` - Positional args for the component. This is the same as calling the component
+          as `{% component "my_comp" arg1 arg2 ... %}`
+        - `kwargs` - Kwargs for the component. This is the same as calling the component
+          as `{% component "my_comp" key1=val1 key2=val2 ... %}`
+        - `slots` - Component slot fills. This is the same as pasing `{% fill %}` tags to the component.
+            Accepts a dictionary of `{ slot_name: slot_content }` where `slot_content` can be a string or render function.
+        - `escape_slots_content` - Whether the content from `slots` should be escaped.
+        - `context` - A context (dictionary or Django's Context) within which the component
+          is rendered. The keys on the context can be accessed from within the template.
+            - NOTE: In "isolated" mode, context is NOT accessible, and data MUST be passed via
+              component's args and kwargs.
+
+        Any additional args and kwargs are passed to the `response_class`.
 
         Example:
         ```py
         MyComponent.render_to_response(
             args=[1, "two", {}],
             kwargs={
-                "key"=123,
+                "key": 123,
             },
             slots={
-                header='STATIC TEXT HERE',
+                "header": 'STATIC TEXT HERE',
+                "footer": lambda ctx, slot_kwargs, slot_ref: f'CTX: {ctx['hello']} SLOT_DATA: {slot_kwargs['abc']}',
             },
             escape_slots_content=False,
+            # HttpResponse input
+            status=201,
+            headers={...},
         )
+        # HttpResponse(content=..., status=201, headers=...)
         ```
         """
         content = cls.render(
@@ -384,15 +408,31 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
         escape_slots_content: bool = True,
     ) -> str:
         """
+        Render the component into a string.
+
+        Inputs:
+        - `args` - Positional args for the component. This is the same as calling the component
+          as `{% component "my_comp" arg1 arg2 ... %}`
+        - `kwargs` - Kwargs for the component. This is the same as calling the component
+          as `{% component "my_comp" key1=val1 key2=val2 ... %}`
+        - `slots` - Component slot fills. This is the same as pasing `{% fill %}` tags to the component.
+            Accepts a dictionary of `{ slot_name: slot_content }` where `slot_content` can be a string or render function.
+        - `escape_slots_content` - Whether the content from `slots` should be escaped.
+        - `context` - A context (dictionary or Django's Context) within which the component
+          is rendered. The keys on the context can be accessed from within the template.
+            - NOTE: In "isolated" mode, context is NOT accessible, and data MUST be passed via
+              component's args and kwargs.
+
         Example:
         ```py
         MyComponent.render(
             args=[1, "two", {}],
             kwargs={
-                "key"=123,
+                "key": 123,
             },
             slots={
-                header='STATIC TEXT HERE',
+                "header": 'STATIC TEXT HERE',
+                "footer": lambda ctx, slot_kwargs, slot_ref: f'CTX: {ctx['hello']} SLOT_DATA: {slot_kwargs['abc']}',
             },
             escape_slots_content=False,
         )

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -361,7 +361,8 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
         - `kwargs` - Kwargs for the component. This is the same as calling the component
           as `{% component "my_comp" key1=val1 key2=val2 ... %}`
         - `slots` - Component slot fills. This is the same as pasing `{% fill %}` tags to the component.
-            Accepts a dictionary of `{ slot_name: slot_content }` where `slot_content` can be a string or render function.
+            Accepts a dictionary of `{ slot_name: slot_content }` where `slot_content` can be a string
+            or render function.
         - `escape_slots_content` - Whether the content from `slots` should be escaped.
         - `context` - A context (dictionary or Django's Context) within which the component
           is rendered. The keys on the context can be accessed from within the template.
@@ -416,7 +417,8 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
         - `kwargs` - Kwargs for the component. This is the same as calling the component
           as `{% component "my_comp" key1=val1 key2=val2 ... %}`
         - `slots` - Component slot fills. This is the same as pasing `{% fill %}` tags to the component.
-            Accepts a dictionary of `{ slot_name: slot_content }` where `slot_content` can be a string or render function.
+            Accepts a dictionary of `{ slot_name: slot_content }` where `slot_content` can be a string
+            or render function.
         - `escape_slots_content` - Whether the content from `slots` should be escaped.
         - `context` - A context (dictionary or Django's Context) within which the component
           is rendered. The keys on the context can be accessed from within the template.

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -202,6 +202,7 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
 
     class Media:
         """Defines JS and CSS media files associated with this component."""
+
         css: Optional[Union[str, List[str], Dict[str, str], Dict[str, List[str]]]] = None
         js: Optional[Union[str, List[str]]] = None
 
@@ -492,14 +493,13 @@ class Component(View, metaclass=SimplifiedInterfaceMediaDefiningClass):
     ) -> Dict[SlotName, FillContent]:
         """Fill component slots outside of template rendering."""
         slot_fills = {}
-        for (slot_name, content) in slots_data.items():
+        for slot_name, content in slots_data.items():
             if isinstance(content, (str, SafeString)):
                 content_func = nodelist_to_render_func(
-                    NodeList([
-                        TextNode(escape(content) if escape_content else content)
-                    ])
+                    NodeList([TextNode(escape(content) if escape_content else content)])
                 )
             else:
+
                 def content_func(ctx: Context) -> RenderedContent:
                     rendered = content(ctx)
                     return escape(rendered) if escape_content else rendered

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -20,7 +20,7 @@ class ComponentRegistry:
 
     def register(self, name: str, component: Type["component.Component"]) -> None:
         existing_component = self._registry.get(name)
-        if existing_component and existing_component.class_hash != component.class_hash:
+        if existing_component and existing_component._class_hash != component._class_hash:
             raise AlreadyRegistered('The component "%s" has already been registered' % name)
         self._registry[name] = component
 

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -13,6 +13,7 @@ RenderFunc = Callable[[Context], RenderedContent]
 def nodelist_to_render_func(nodelist: NodeList) -> RenderFunc:
     def render_func(ctx: Context) -> RenderedContent:
         return nodelist.render(ctx)
+
     return render_func
 
 

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -1,9 +1,19 @@
-from typing import Callable, List, NamedTuple, Optional
+from typing import Callable, List, NamedTuple, Optional, Union
 
 from django.template import Context, Template
 from django.template.base import Node, NodeList, TextNode
 from django.template.defaulttags import CommentNode
 from django.template.loader_tags import ExtendsNode, IncludeNode, construct_relative_path
+from django.utils.safestring import SafeText
+
+RenderedContent = Union[str, SafeText]
+RenderFunc = Callable[[Context], RenderedContent]
+
+
+def nodelist_to_render_func(nodelist: NodeList) -> RenderFunc:
+    def render_func(ctx: Context) -> RenderedContent:
+        return nodelist.render(ctx)
+    return render_func
 
 
 def nodelist_has_content(nodelist: NodeList) -> bool:

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -1,20 +1,9 @@
-from typing import Callable, List, NamedTuple, Optional, Union
+from typing import Callable, List, NamedTuple, Optional
 
 from django.template import Context, Template
 from django.template.base import Node, NodeList, TextNode
 from django.template.defaulttags import CommentNode
 from django.template.loader_tags import ExtendsNode, IncludeNode, construct_relative_path
-from django.utils.safestring import SafeText
-
-RenderedContent = Union[str, SafeText]
-RenderFunc = Callable[[Context], RenderedContent]
-
-
-def nodelist_to_render_func(nodelist: NodeList) -> RenderFunc:
-    def render_func(ctx: Context) -> RenderedContent:
-        return nodelist.render(ctx)
-
-    return render_func
 
 
 def nodelist_has_content(nodelist: NodeList) -> bool:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -477,3 +477,35 @@ class ComponentRenderTest(BaseTestCase):
 
             """,
         )
+
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_render_can_access_instance(self):
+        class TestComponent(component.Component):
+            template = "Variable: <strong>{{ id }}</strong>"
+
+            def get_context_data(self, **attrs):
+                return {
+                    "id": self.component_id,
+                }
+
+        rendered = TestComponent(component_id="123").render()
+        self.assertHTMLEqual(
+            rendered,
+            "Variable: <strong>123</strong>",
+        )
+
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_render_to_response_can_access_instance(self):
+        class TestComponent(component.Component):
+            template = "Variable: <strong>{{ id }}</strong>"
+
+            def get_context_data(self, **attrs):
+                return {
+                    "id": self.component_id,
+                }
+
+        rendered_resp = TestComponent(component_id="123").render_to_response()
+        self.assertHTMLEqual(
+            rendered_resp.content.decode('utf-8'),
+            "Variable: <strong>123</strong>",
+        )

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -506,6 +506,6 @@ class ComponentRenderTest(BaseTestCase):
 
         rendered_resp = TestComponent(component_id="123").render_to_response()
         self.assertHTMLEqual(
-            rendered_resp.content.decode('utf-8'),
+            rendered_resp.content.decode("utf-8"),
             "Variable: <strong>123</strong>",
         )

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -3,8 +3,8 @@ Tests focusing on the Component class.
 For tests focusing on the `component` tag, see `test_templatetags_component.py`
 """
 
-from django.http import HttpResponse
 from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
 from django.template import Context, Template, TemplateSyntaxError
 
 # isort: off

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -335,6 +335,24 @@ class ComponentRenderTest(BaseTestCase):
             """,
         )
 
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_render_to_response_change_response_class(self):
+        class MyResponse:
+            def __init__(self, content: str) -> None:
+                self.content = bytes(content, "utf-8")
+
+        class SimpleComponent(component.Component):
+            response_class = MyResponse
+            template: types.django_html = "HELLO"
+
+        rendered = SimpleComponent.render_to_response()
+        self.assertIsInstance(rendered, MyResponse)
+
+        self.assertHTMLEqual(
+            rendered.content.decode(),
+            "HELLO",
+        )
+
     @parametrize_context_behavior([("django", False), ("isolated", True)])
     def test_render_slot_as_func(self, context_behavior_data):
         is_isolated = context_behavior_data

--- a/tests/test_component_as_view.py
+++ b/tests/test_component_as_view.py
@@ -69,16 +69,16 @@ class TestComponentAsView(BaseTestCase):
             template = """
                 <form method="post">
                     {% csrf_token %}
-                    <input type="text" name="variable" value="{{ variable }}">
+                    <input type="text" name="variable" value="{{ inner_var }}">
                     <input type="submit">
                 </form>
                 """
 
             def get(self, request, *args, **kwargs) -> HttpResponse:
-                return self.render_to_response({"variable": "GET"})
+                return self.render_to_response(kwargs={"variable": "GET"})
 
-            def get_context_data(self, variable, *args, **kwargs) -> Dict[str, Any]:
-                return {"variable": variable}
+            def get_context_data(self, variable):
+                return {"inner_var": variable}
 
         client = CustomClient(urlpatterns=[path("test/", MockComponentRequest.as_view())])
         response = client.get("/test/")
@@ -93,17 +93,17 @@ class TestComponentAsView(BaseTestCase):
             template = """
                 <form method="post">
                     {% csrf_token %}
-                    <input type="text" name="variable" value="{{ variable }}">
+                    <input type="text" name="variable" value="{{ inner_var }}">
                     <input type="submit">
                 </form>
                 """
 
             def post(self, request, *args, **kwargs) -> HttpResponse:
                 variable = request.POST.get("variable")
-                return self.render_to_response({"variable": variable})
+                return self.render_to_response(kwargs={"variable": variable})
 
-            def get_context_data(self, variable, *args, **kwargs) -> Dict[str, Any]:
-                return {"variable": variable}
+            def get_context_data(self, variable):
+                return {"inner_var": variable}
 
         client = CustomClient(urlpatterns=[path("test/", MockComponentRequest.as_view())])
         response = client.post("/test/", {"variable": "POST"})

--- a/tests/test_component_media.py
+++ b/tests/test_component_media.py
@@ -141,9 +141,7 @@ class InlineComponentTest(BaseTestCase):
                     "var2": var2,
                 }
 
-        rendered = FilteredComponent.render(
-            kwargs={"var1": "test1", "var2": "test2"}
-        )
+        rendered = FilteredComponent.render(kwargs={"var1": "test1", "var2": "test2"})
         self.assertHTMLEqual(
             rendered,
             """

--- a/tests/test_component_media.py
+++ b/tests/test_component_media.py
@@ -141,11 +141,11 @@ class InlineComponentTest(BaseTestCase):
                     "var2": var2,
                 }
 
-        comp = FilteredComponent("filtered_component")
-        context = Context(comp.get_context_data(var1="test1", var2="test2"))
-
+        rendered = FilteredComponent.render(
+            kwargs={"var1": "test1", "var2": "test2"}
+        )
         self.assertHTMLEqual(
-            comp.render(context),
+            rendered,
             """
             Var1: <strong>test1</strong>
             Var2 (uppercased): <strong>TEST2</strong>


### PR DESCRIPTION
Initial implementation for https://github.com/EmilStenstrom/django-components/issues/520.

See individual comments for details.

What still remains is to do:
- [x] Document the changes in README
- [x] Update docstrings of `render` and `render_to_response`

Closes #520