### PR TITLE
add support for jsx notation

### DIFF
--- a/src/django_components/utils.py
+++ b/src/django_components/utils.py
@@ -1,7 +1,9 @@
 import glob
 from pathlib import Path
 from typing import Any, Callable, List, NamedTuple, Optional
+
 from django.template.engine import Engine
+
 from django_components import types as t
 from django_components.template_loader import Loader
 

--- a/src/django_components/utils.py
+++ b/src/django_components/utils.py
@@ -1,9 +1,8 @@
 import glob
 from pathlib import Path
 from typing import Any, Callable, List, NamedTuple, Optional
-
 from django.template.engine import Engine
-
+from django_components import types as t
 from django_components.template_loader import Loader
 
 
@@ -56,3 +55,31 @@ def find_last_index(lst: List, predicate: Callable[[Any], bool]) -> Any:
         if predicate(elem):
             return len(lst) - 1 - r_idx
     return -1
+
+
+def jsx2django_components(jsx: t.django_html):
+    html = jsx
+    more_components = True
+
+    while more_components:
+        tag = ""
+        try:
+            tag = jsx.split("<")[1].split("/>")[0]
+        except:
+            more_components = False
+            continue
+        if not tag:
+            more_components = False
+            continue
+
+        is_compoment = not str(tag)[0].isupper()
+        if is_compoment:
+            jsx = jsx.split(tag)[1]
+            continue
+        component_name, attributes = tag.split(" ", 1)
+
+        parsed_component = "{% component '" + component_name + "' " + attributes + "%} {% endcomponent %}"
+
+        html = html.replace("<" + tag + "/>", parsed_component)
+        jsx = jsx.split(tag)[1]
+    return html


### PR DESCRIPTION
a simple translator for React-ish developers to be able to write in JSX.
makes the experience of the signal file view-component feels like Remix and Python got married and had a child.


Usage:
```
template = jsx2django_components(
    <body>
      <Head title="this is a prop for the Header component title" />
         <body class="text-center">
         <h1> A beautiful Web App</h1>
         <h2 class="text-2xl "> HomePage is here </h2>
      <Footer logo="this is a prop for the logo in the Footer component" />
    </body>
```)
