### PR TITLE
fix: various fixes for inject/provide and html_attrs

### DIFF
--- a/src/django_components/attributes.py
+++ b/src/django_components/attributes.py
@@ -15,6 +15,10 @@ HTML_ATTRS_DEFAULTS_KEY = "defaults"
 HTML_ATTRS_ATTRS_KEY = "attrs"
 
 
+def _default(val: Any, default_val: Any) -> Any:
+    return val if val is not None else default_val
+
+
 class HtmlAttrsNode(Node):
     def __init__(
         self,
@@ -57,8 +61,9 @@ class HtmlAttrsNode(Node):
         attrs_and_defaults_from_kwargs = process_aggregate_kwargs(attrs_and_defaults_from_kwargs)
 
         # NOTE: We want to allow to use `html_attrs` even without `attrs` or `defaults` params
-        attrs = attrs_and_defaults_from_kwargs.get(HTML_ATTRS_ATTRS_KEY, {})
-        default_attrs = attrs_and_defaults_from_kwargs.get(HTML_ATTRS_DEFAULTS_KEY, {})
+        # Or when they are None
+        attrs = _default(attrs_and_defaults_from_kwargs.get(HTML_ATTRS_ATTRS_KEY, None), {})
+        default_attrs = _default(attrs_and_defaults_from_kwargs.get(HTML_ATTRS_DEFAULTS_KEY, None), {})
 
         final_attrs = {**default_attrs, **attrs}
         final_attrs = append_attributes(*final_attrs.items(), *append_attrs)

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -10,7 +10,7 @@ from django.template.context import Context
 from django.template.exceptions import TemplateSyntaxError
 from django.template.loader import get_template
 from django.template.loader_tags import BLOCK_CONTEXT_KEY
-from django.utils.html import escape
+from django.utils.html import conditional_escape
 from django.utils.safestring import SafeString, mark_safe
 from django.views import View
 
@@ -441,13 +441,13 @@ class Component(View, metaclass=ComponentMeta):
         for slot_name, content in slots_data.items():
             if isinstance(content, (str, SafeString)):
                 content_func = _nodelist_to_slot_render_func(
-                    NodeList([TextNode(escape(content) if escape_content else content)])
+                    NodeList([TextNode(conditional_escape(content) if escape_content else content)])
                 )
             else:
 
                 def content_func(ctx: Context, kwargs: Dict[str, Any], slot_ref: SlotRef) -> SlotRenderedContent:
                     rendered = content(ctx, kwargs, slot_ref)
-                    return escape(rendered) if escape_content else rendered
+                    return conditional_escape(rendered) if escape_content else rendered
 
             slot_fills[slot_name] = FillContent(
                 content_func=content_func,

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -337,7 +337,21 @@ class Component(View, metaclass=ComponentMeta):
 
         return comp._render(context, args, kwargs, slots, escape_slots_content)
 
+    # This is the internal entrypoint for the render function
     def _render(
+        self,
+        context: Union[Dict[str, Any], Context] = None,
+        args: Optional[Union[List, Tuple]] = None,
+        kwargs: Optional[Dict[str, Any]] = None,
+        slots: Optional[Mapping[SlotName, SlotContent]] = None,
+        escape_slots_content: bool = True,
+    ) -> str:
+        try:
+            return self._render_impl(context, args, kwargs, slots, escape_slots_content)
+        except Exception as err:
+            raise RuntimeError(f"An error occured while rendering component '{self.name}'") from err
+
+    def _render_impl(
         self,
         context: Union[Dict[str, Any], Context] = None,
         args: Optional[Union[List, Tuple]] = None,

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -349,7 +349,7 @@ class Component(View, metaclass=ComponentMeta):
         try:
             return self._render_impl(context, args, kwargs, slots, escape_slots_content)
         except Exception as err:
-            raise RuntimeError(f"An error occured while rendering component '{self.name}'") from err
+            raise type(err)(f"An error occured while rendering component '{self.name}':\n{repr(err)}") from err
 
     def _render_impl(
         self,

--- a/src/django_components/context.py
+++ b/src/django_components/context.py
@@ -100,7 +100,7 @@ def get_injected_context_var(
     # Otherwise raise error
     raise KeyError(
         f"Component '{component_name}' tried to inject a variable '{key}' before it was provided."
-        f"To fix this, make sure that at least one ancestor of component '{component_name}' has"
+        f" To fix this, make sure that at least one ancestor of component '{component_name}' has"
         f" the variable '{key}' in their 'provide' attribute."
     )
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -131,13 +131,10 @@ class HtmlAttrsTests(BaseTestCase):
 
         template = Template(self.template_str)
 
-        try:
+        with self.assertRaisesMessage(
+            TemplateSyntaxError, "Tag 'html_attrs' received unexpected positional arguments"
+        ):
             template.render(Context({"class_var": "padding-top-8"}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
-            self.assertIn("Tag 'html_attrs' received unexpected positional arguments", str(err.__cause__))
-        else:
-            self.fail("Expected call to fail")
 
     def test_tag_kwargs(self):
         @component.register("test")
@@ -237,13 +234,8 @@ class HtmlAttrsTests(BaseTestCase):
 
         template = Template(self.template_str)
 
-        try:
+        with self.assertRaisesMessage(TemplateSyntaxError, "Received argument 'attrs' both as a regular input"):
             template.render(Context({"class_var": "padding-top-8"}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
-            self.assertIn("Received argument 'attrs' both as a regular input", str(err.__cause__))
-        else:
-            self.fail("Expected call to fail")
 
     def test_tag_raises_on_aggregate_and_positional_args_for_defaults(self):
         @component.register("test")
@@ -260,13 +252,11 @@ class HtmlAttrsTests(BaseTestCase):
 
         template = Template(self.template_str)
 
-        try:
+        with self.assertRaisesMessage(
+            TemplateSyntaxError,
+            "Received argument 'defaults' both as a regular input",
+        ):
             template.render(Context({"class_var": "padding-top-8"}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
-            self.assertIn("Received argument 'defaults' both as a regular input", str(err.__cause__))
-        else:
-            self.fail("Expected call to fail")
 
     def test_tag_no_attrs(self):
         @component.register("test")

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -131,10 +131,13 @@ class HtmlAttrsTests(BaseTestCase):
 
         template = Template(self.template_str)
 
-        with self.assertRaisesMessage(
-            TemplateSyntaxError, "Tag 'html_attrs' received unexpected positional arguments"
-        ):
+        try:
             template.render(Context({"class_var": "padding-top-8"}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
+            self.assertIn("Tag 'html_attrs' received unexpected positional arguments", str(err.__cause__))
+        else:
+            self.fail("Expected call to fail")
 
     def test_tag_kwargs(self):
         @component.register("test")
@@ -233,8 +236,14 @@ class HtmlAttrsTests(BaseTestCase):
                 return {"attrs": attrs}
 
         template = Template(self.template_str)
-        with self.assertRaisesMessage(TemplateSyntaxError, "Received argument 'attrs' both as a regular input"):
+
+        try:
             template.render(Context({"class_var": "padding-top-8"}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
+            self.assertIn("Received argument 'attrs' both as a regular input", str(err.__cause__))
+        else:
+            self.fail("Expected call to fail")
 
     def test_tag_raises_on_aggregate_and_positional_args_for_defaults(self):
         @component.register("test")
@@ -250,11 +259,14 @@ class HtmlAttrsTests(BaseTestCase):
                 return {"attrs": attrs}
 
         template = Template(self.template_str)
-        with self.assertRaisesMessage(
-            TemplateSyntaxError,
-            "Received argument 'defaults' both as a regular input",
-        ):
+
+        try:
             template.render(Context({"class_var": "padding-top-8"}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
+            self.assertIn("Received argument 'defaults' both as a regular input", str(err.__cause__))
+        else:
+            self.fail("Expected call to fail")
 
     def test_tag_no_attrs(self):
         @component.register("test")

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -423,12 +423,8 @@ class ComponentRenderTest(BaseTestCase):
                 {% endslot %}
             """
 
-        try:
+        with self.assertRaises(TemplateSyntaxError):
             SimpleComponent.render()
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
-        else:
-            self.fail("Expected call to fail")
 
         SimpleComponent.render(
             slots={"first": "FIRST_SLOT"},

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -423,8 +423,12 @@ class ComponentRenderTest(BaseTestCase):
                 {% endslot %}
             """
 
-        with self.assertRaises(TemplateSyntaxError):
+        try:
             SimpleComponent.render()
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
+        else:
+            self.fail("Expected call to fail")
 
         SimpleComponent.render(
             slots={"first": "FIRST_SLOT"},

--- a/tests/test_templatetags_provide.py
+++ b/tests/test_templatetags_provide.py
@@ -481,6 +481,45 @@ class ProvideTemplateTagTest(BaseTestCase):
             """,
         )
 
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_slot_in_provide(self):
+        @component.register("injectee")
+        class InjectComponent(component.Component):
+            template: types.django_html = """
+                <div> injected: {{ var|safe }} </div>
+            """
+
+            def get_context_data(self):
+                var = self.inject("my_provide", "default")
+                return {"var": var}
+
+        @component.register("parent")
+        class ParentComponent(component.Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                {% provide "my_provide" key="hi" another=123 %}
+                    {% slot "content" default %}{% endslot %}
+                {% endprovide %}
+            """
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% component "parent" %}
+                {% component "injectee" %}{% endcomponent %}
+            {% endcomponent %}
+        """
+        template = Template(template_str)
+        rendered = template.render(Context({}))
+
+        self.assertHTMLEqual(
+            rendered,
+            """
+            <div>
+                injected: DepInject(key='hi', another=123)
+            </div>
+            """,
+        )
+
 
 class InjectTest(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
@@ -530,8 +569,13 @@ class InjectTest(BaseTestCase):
             {% endcomponent %}
         """
         template = Template(template_str)
-        with self.assertRaises(KeyError):
+
+        try:
             template.render(Context({}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, KeyError)
+        else:
+            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_inject_missing_key_ok_with_default(self):
@@ -581,8 +625,13 @@ class InjectTest(BaseTestCase):
             {% endcomponent %}
         """
         template = Template(template_str)
-        with self.assertRaises(KeyError):
+
+        try:
             template.render(Context({}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, KeyError)
+        else:
+            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_inject_raises_on_called_outside_get_context_data(self):

--- a/tests/test_templatetags_provide.py
+++ b/tests/test_templatetags_provide.py
@@ -570,12 +570,8 @@ class InjectTest(BaseTestCase):
         """
         template = Template(template_str)
 
-        try:
+        with self.assertRaises(KeyError):
             template.render(Context({}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, KeyError)
-        else:
-            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_inject_missing_key_ok_with_default(self):
@@ -626,12 +622,8 @@ class InjectTest(BaseTestCase):
         """
         template = Template(template_str)
 
-        try:
+        with self.assertRaises(KeyError):
             template.render(Context({}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, KeyError)
-        else:
-            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_inject_raises_on_called_outside_get_context_data(self):

--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -210,8 +210,13 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
             {% endcomponent %}
         """
         template = Template(template_str)
-        with self.assertRaises(TemplateSyntaxError):
+
+        try:
             template.render(Context({}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
+        else:
+            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_default_slot_is_fillable_by_implicit_fill_content(self):
@@ -284,8 +289,13 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
             {% endcomponent %}
         """
         template = Template(template_str)
-        with self.assertRaises(TemplateSyntaxError):
+
+        try:
             template.render(Context({}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
+        else:
+            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_fill_tag_can_occur_within_component_nested_in_implicit_fill(self):
@@ -381,8 +391,13 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
             {% endcomponent %}
         """
         template = Template(template_str)
-        with self.assertRaises(TemplateSyntaxError):
+
+        try:
             template.render(Context({}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
+        else:
+            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_component_template_cannot_have_multiple_default_slots(self):
@@ -398,8 +413,13 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
                 return Template(template_str)
 
         c = BadComponent("name")
-        with self.assertRaises(TemplateSyntaxError):
+
+        try:
             c.render(Context({}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
+        else:
+            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_slot_name_fill_typo_gives_helpful_error_message(self):
@@ -417,20 +437,22 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
             {% endcomponent %}
         """
         template = Template(template_str)
-        with self.assertRaises(TemplateSyntaxError):
-            try:
-                template.render(Context({}))
-            except TemplateSyntaxError as e:
-                self.assertEqual(
-                    textwrap.dedent(
-                        """\
-                        Component 'test1' passed fill that refers to undefined slot: 'haeder'.
-                        Unfilled slot names are: ['footer', 'header'].
-                        Did you mean 'header'?"""
-                    ),
-                    str(e),
-                )
-                raise e
+
+        try:
+            template.render(Context({}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
+            self.assertEqual(
+                textwrap.dedent(
+                    """\
+                    Component 'test1' passed fill that refers to undefined slot: 'haeder'.
+                    Unfilled slot names are: ['footer', 'header'].
+                    Did you mean 'header'?"""
+                ),
+                str(err.__cause__),
+            )
+        else:
+            self.fail("Expected call to fail")
 
     # NOTE: This is relevant only for the "isolated" mode
     @parametrize_context_behavior(["isolated"])
@@ -1144,16 +1166,21 @@ class SlotFillTemplateSyntaxErrorTests(BaseTestCase):
                 {% include 'slotted_template.html' with context=None only %}
             """
 
-        with self.assertRaises(KeyError):
-            template_str: types.django_html = """
-                {% load component_tags %}
-                {% component "broken_component" %}
-                    {% fill "header" %}Custom header {% endfill %}
-                    {% fill "main" %}Custom main{% endfill %}
-                    {% fill "footer" %}Custom footer{% endfill %}
-                {% endcomponent %}
-            """
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% component "broken_component" %}
+                {% fill "header" %}Custom header {% endfill %}
+                {% fill "main" %}Custom main{% endfill %}
+                {% fill "footer" %}Custom footer{% endfill %}
+            {% endcomponent %}
+        """
+
+        try:
             Template(template_str).render(Context({}))
+        except RuntimeError as err:
+            self.assertIsInstance(err.__cause__, KeyError)
+        else:
+            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_non_unique_fill_names_is_error(self):

--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -1,4 +1,3 @@
-import textwrap
 from typing import Any, Dict, List, Optional
 
 from django.template import Context, Template, TemplateSyntaxError
@@ -211,12 +210,8 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
         """
         template = Template(template_str)
 
-        try:
+        with self.assertRaises(TemplateSyntaxError):
             template.render(Context({}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
-        else:
-            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_default_slot_is_fillable_by_implicit_fill_content(self):
@@ -290,12 +285,8 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
         """
         template = Template(template_str)
 
-        try:
+        with self.assertRaises(TemplateSyntaxError):
             template.render(Context({}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
-        else:
-            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_fill_tag_can_occur_within_component_nested_in_implicit_fill(self):
@@ -392,12 +383,8 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
         """
         template = Template(template_str)
 
-        try:
+        with self.assertRaises(TemplateSyntaxError):
             template.render(Context({}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
-        else:
-            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_component_template_cannot_have_multiple_default_slots(self):
@@ -414,12 +401,8 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
 
         c = BadComponent("name")
 
-        try:
+        with self.assertRaises(TemplateSyntaxError):
             c.render(Context({}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
-        else:
-            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_slot_name_fill_typo_gives_helpful_error_message(self):
@@ -438,21 +421,15 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
         """
         template = Template(template_str)
 
-        try:
-            template.render(Context({}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, TemplateSyntaxError)
-            self.assertEqual(
-                textwrap.dedent(
-                    """\
-                    Component 'test1' passed fill that refers to undefined slot: 'haeder'.
-                    Unfilled slot names are: ['footer', 'header'].
-                    Did you mean 'header'?"""
-                ),
-                str(err.__cause__),
+        with self.assertRaisesMessage(
+            TemplateSyntaxError,
+            (
+                "Component 'test1' passed fill that refers to undefined slot: 'haeder'.\\n"
+                "Unfilled slot names are: ['footer', 'header'].\\n"
+                "Did you mean 'header'?"
             )
-        else:
-            self.fail("Expected call to fail")
+        ):
+            template.render(Context({}))
 
     # NOTE: This is relevant only for the "isolated" mode
     @parametrize_context_behavior(["isolated"])
@@ -1175,12 +1152,8 @@ class SlotFillTemplateSyntaxErrorTests(BaseTestCase):
             {% endcomponent %}
         """
 
-        try:
+        with self.assertRaises(KeyError):
             Template(template_str).render(Context({}))
-        except RuntimeError as err:
-            self.assertIsInstance(err.__cause__, KeyError)
-        else:
-            self.fail("Expected call to fail")
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_non_unique_fill_names_is_error(self):

--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -427,7 +427,7 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
                 "Component 'test1' passed fill that refers to undefined slot: 'haeder'.\\n"
                 "Unfilled slot names are: ['footer', 'header'].\\n"
                 "Did you mean 'header'?"
-            )
+            ),
         ):
             template.render(Context({}))
 


### PR DESCRIPTION
I came across these errors when upgrading from django-components v0.73 to v0.82:

- fix: Do not escape already escaped slots when slots are given to `slots` kwarg in `Component.render`

- fix: html_attrs allow `attrs` and `defaults` to be `None`

- fix: slots inside `{% provide %}` should have access to provided values

Also modified the raised errors from inside the components' `render` function, so it shows info on which component (name) raised the error.