### PR TITLE
fix: do not aggregate kwargs that start with colon

### DIFF
--- a/src/django_components/template_parser.py
+++ b/src/django_components/template_parser.py
@@ -261,7 +261,9 @@ def process_aggregate_kwargs(kwargs: Mapping[str, Any]) -> Dict[str, Any]:
     processed_kwargs = {}
     nested_kwargs: Dict[str, Dict[str, Any]] = {}
     for key, val in kwargs.items():
-        if ":" not in key:
+        # NOTE: If we get a key that starts with `:`, like `:class`, we do not split it.
+        # This syntax is used by Vue and AlpineJS.
+        if ":" not in key or key.startswith(":"):
             processed_kwargs[key] = val
             continue
 

--- a/tests/test_template_parser.py
+++ b/tests/test_template_parser.py
@@ -88,3 +88,29 @@ class ParserComponentTest(BaseTestCase):
             abc
             """,
         )
+
+
+class AggregateKwargsTest(BaseTestCase):
+    def test_aggregate_kwargs(self):
+        processed = process_aggregate_kwargs({
+          "attrs:@click.stop": "dispatch('click_event')",
+          "attrs:x-data": "{hello: 'world'}",
+          "attrs:class": "class_var",
+          "my_dict:one": 2,
+          "three": "four",
+          ":placeholder": "No text",
+        })
+
+        self.assertDictEqual(
+            processed,
+            {
+                "attrs": {
+                    "@click.stop": "dispatch('click_event')",
+                    "x-data": "{hello: 'world'}",
+                    "class": "class_var",
+                },
+                "my_dict": {"one": 2},
+                "three": "four",
+                ":placeholder": "No text",
+            }
+        )

--- a/tests/test_template_parser.py
+++ b/tests/test_template_parser.py
@@ -4,6 +4,7 @@ from django.template.base import Parser
 from django_components import component, types
 from django_components.component import safe_resolve_dict, safe_resolve_list
 from django_components.templatetags.component_tags import _parse_component_with_args
+from django_components.template_parser import process_aggregate_kwargs
 
 from .django_test_setup import setup_test_config
 from .testutils import BaseTestCase, parametrize_context_behavior

--- a/tests/test_template_parser.py
+++ b/tests/test_template_parser.py
@@ -3,8 +3,8 @@ from django.template.base import Parser
 
 from django_components import component, types
 from django_components.component import safe_resolve_dict, safe_resolve_list
-from django_components.templatetags.component_tags import _parse_component_with_args
 from django_components.template_parser import process_aggregate_kwargs
+from django_components.templatetags.component_tags import _parse_component_with_args
 
 from .django_test_setup import setup_test_config
 from .testutils import BaseTestCase, parametrize_context_behavior
@@ -93,14 +93,16 @@ class ParserComponentTest(BaseTestCase):
 
 class AggregateKwargsTest(BaseTestCase):
     def test_aggregate_kwargs(self):
-        processed = process_aggregate_kwargs({
-          "attrs:@click.stop": "dispatch('click_event')",
-          "attrs:x-data": "{hello: 'world'}",
-          "attrs:class": "class_var",
-          "my_dict:one": 2,
-          "three": "four",
-          ":placeholder": "No text",
-        })
+        processed = process_aggregate_kwargs(
+            {
+                "attrs:@click.stop": "dispatch('click_event')",
+                "attrs:x-data": "{hello: 'world'}",
+                "attrs:class": "class_var",
+                "my_dict:one": 2,
+                "three": "four",
+                ":placeholder": "No text",
+            }
+        )
 
         self.assertDictEqual(
             processed,
@@ -113,5 +115,5 @@ class AggregateKwargsTest(BaseTestCase):
                 "my_dict": {"one": 2},
                 "three": "four",
                 ":placeholder": "No text",
-            }
+            },
         )


### PR DESCRIPTION
We have the feature of "aggregating kwargs", meaning that if I pass following kwarg to a component, `prop:key=value`, then this gets interpreted as "passing kwarg 'prop', which is a dict `{"key": value}`.

As per https://github.com/EmilStenstrom/django-components/discussions/556#discussioncomment-10182903, currently we "aggregate" even component kwargs that start with colon (`:`). These should be ignored.