### PR TITLE
Fix upgradecomponent

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ And this is what gets rendered (plus the CSS and Javascript you've specified):
 
 **Version 0.67** CHANGED the default way how context variables are resolved in slots. See the [documentation](https://github.com/EmilStenstrom/django-components/tree/0.67#isolate-components-slots) for more details.
 
-🚨📢 **Version 0.5** CHANGES THE SYNTAX for components. `component_block` is now `component`, and `component` blocks need an ending `endcomponent` tag. The new `python manage.py upgradecomponent` command can be used to upgrade a directory (use --path argument to point to each dir) of components to the new syntax automatically.
+🚨📢 **Version 0.5** CHANGES THE SYNTAX for components. `component_block` is now `component`, and `component` blocks need an ending `endcomponent` tag. The new `python manage.py upgradecomponent` command can be used to upgrade a directory (use --path argument to point to each dir) of templates that use components to the new syntax automatically.
 
 This change is done to simplify the API in anticipation of a 1.0 release of django_components. After 1.0 we intend to be stricter with big changes like this in point releases.
 

--- a/src/django_components/management/commands/upgradecomponent.py
+++ b/src/django_components/management/commands/upgradecomponent.py
@@ -54,15 +54,16 @@ class Command(BaseCommand):
                                 flags=re.DOTALL,
                             )
                             updated_content, step2_count_closing_no_name = re.subn(
-                                r"{%\s*endcomponent_block\s*%}", r"{% endcomponent %}", updated_content, flags=re.DOTALL
+                                r"{%\s*endcomponent_block\s*%}",
+                                r"{% endcomponent %}",
+                                updated_content,
+                                flags=re.DOTALL,
                             )
                             total_updates = (
-                                step0_count + step1_count_opening +
-                                step2_count_closing + step2_count_closing_no_name
+                                step0_count + step1_count_opening + step2_count_closing + step2_count_closing_no_name
                             )
                             if total_updates > 0:
                                 f.seek(0)
                                 f.write(updated_content)
                                 f.truncate()
-                                self.stdout.write(
-                                    f"Updated {file_path}: {total_updates} changes made")
+                                self.stdout.write(f"Updated {file_path}: {total_updates} changes made")

--- a/src/django_components/management/commands/upgradecomponent.py
+++ b/src/django_components/management/commands/upgradecomponent.py
@@ -33,34 +33,36 @@ class Command(BaseCommand):
                 for file in files:
                     if file.endswith((".html", ".py")):
                         file_path = os.path.join(root, file)
-                    with open(file_path, "r+", encoding="utf-8") as f:
-                        content = f.read()
-                        content_with_closed_components, step0_count = re.subn(
-                            r'({%\s*component\s*"(\w+?)"(.*?)%})(?!.*?{%\s*endcomponent\s*%})',
-                            r"\1{% endcomponent %}",
-                            content,
-                            flags=re.DOTALL,
-                        )
-                        updated_content, step1_count_opening = re.subn(
-                            r'{%\s*component_block\s*"(\w+?)"\s*(.*?)%}',
-                            r'{% component "\1" \2%}',
-                            content_with_closed_components,
-                            flags=re.DOTALL,
-                        )
-                        updated_content, step2_count_closing = re.subn(
-                            r'{%\s*endcomponent_block\s*"(\w+?)"\s*%}',
-                            r"{% endcomponent %}",
-                            updated_content,
-                            flags=re.DOTALL,
-                        )
-                        updated_content, step2_count_closing_no_name = re.subn(
-                            r"{%\s*endcomponent_block\s*%}", r"{% endcomponent %}", updated_content, flags=re.DOTALL
-                        )
-                        total_updates = (
-                            step0_count + step1_count_opening + step2_count_closing + step2_count_closing_no_name
-                        )
-                        if total_updates > 0:
-                            f.seek(0)
-                            f.write(updated_content)
-                            f.truncate()
-                            self.stdout.write(f"Updated {file_path}: {total_updates} changes made")
+                        with open(file_path, "r+", encoding="utf-8") as f:
+                            content = f.read()
+                            content_with_closed_components, step0_count = re.subn(
+                                r'({%\s*component\s*"(\w+?)"(.*?)%})(?!.*?{%\s*endcomponent\s*%})',
+                                r"\1{% endcomponent %}",
+                                content,
+                                flags=re.DOTALL,
+                            )
+                            updated_content, step1_count_opening = re.subn(
+                                r'{%\s*component_block\s*"(\w+?)"\s*(.*?)%}',
+                                r'{% component "\1" \2%}',
+                                content_with_closed_components,
+                                flags=re.DOTALL,
+                            )
+                            updated_content, step2_count_closing = re.subn(
+                                r'{%\s*endcomponent_block\s*"(\w+?)"\s*%}',
+                                r"{% endcomponent %}",
+                                updated_content,
+                                flags=re.DOTALL,
+                            )
+                            updated_content, step2_count_closing_no_name = re.subn(
+                                r"{%\s*endcomponent_block\s*%}", r"{% endcomponent %}", updated_content, flags=re.DOTALL
+                            )
+                            total_updates = (
+                                step0_count + step1_count_opening +
+                                step2_count_closing + step2_count_closing_no_name
+                            )
+                            if total_updates > 0:
+                                f.seek(0)
+                                f.write(updated_content)
+                                f.truncate()
+                                self.stdout.write(
+                                    f"Updated {file_path}: {total_updates} changes made")


### PR DESCRIPTION
Just tried to run this on my production codebase and ran into this easily reproducible issue:

```
    with open(file_path, "r+", encoding="utf-8") as f:
              ^^^^^^^^^
UnboundLocalError: cannot access local variable 'file_path' where it is not associated with a value
```

Also clarified the verbiage in the README for anyone else updating from an archaic version (maybe I'm the only one), but it took me a bit to realize I point this at my templates, not components dir.

Note that this still didn't get me 100% of the way there, but it went from 0-50 and saved me a ton of time. Still missing lots of opening component_block tags and plenty more {% endcomponent %}.