### PR TITLE
refactor: prepare registry for custom template tags and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ target/
 # lock file is not needed for development
 # as project supports variety of Django versions
 poetry.lock
-pyproject.toml
 
 # PyCharm
 .idea/

--- a/README.md
+++ b/README.md
@@ -745,6 +745,7 @@ then the default Library instance from django_components is used.
 
 ```py
 from django.template import Library
+from django_components import ComponentRegistry
 
 my_library = Library(...)
 my_registry = ComponentRegistry(library=my_library)

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -2,8 +2,6 @@ from typing import TYPE_CHECKING, Callable, Dict, List, NamedTuple, Optional, Se
 
 from django.template import Library
 
-from django_components.tag_formatter import get_component_tag_formatter
-
 if TYPE_CHECKING:
     from django_components.component import Component
 
@@ -111,7 +109,7 @@ class ComponentRegistry:
         if existing_component and existing_component.cls._class_hash != component._class_hash:
             raise AlreadyRegistered('The component "%s" has already been registered' % name)
 
-        used_tags = self._register_to_library(name)
+        used_tags = ["component"]
 
         # Keep track of which components use which tags, because multiple components may
         # use the same tag.
@@ -230,24 +228,6 @@ class ComponentRegistry:
         self._registry = {}
         self._tags = {}
 
-    def _register_to_library(self, comp_name: str) -> List[str]:
-        from django_components.templatetags.component_tags import (
-            create_block_component_tag,
-            create_inline_component_tag,
-        )
-
-        formatter = get_component_tag_formatter()
-
-        # register the inline tag
-        inline_tag = formatter.safe_format_inline_tag(comp_name)
-        self.library.tag(inline_tag, create_inline_component_tag)
-
-        # register the block tag
-        block_tag = formatter.safe_format_block_start_tag(comp_name)
-        self.library.tag(block_tag, create_block_component_tag)
-
-        used_tags = [inline_tag, block_tag]
-        return used_tags
 
 
 # This variable represents the global component registry

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -78,7 +78,7 @@ class ComponentRegistry:
         """
         The template tag library with which the component registry is associated.
         """
-        # Use the default library if none was passed
+        # Lazily use the default library if none was passed
         if self._library is not None:
             lib = self._library
         else:
@@ -156,8 +156,10 @@ class ComponentRegistry:
             if is_tag_empty:
                 del self._tags[tag]
 
+            is_protected = tag in {"component", "#component"}
+
             # Unregister the tag from library if this was the last component using this tag
-            if is_tag_empty and tag in self.library.tags:
+            if is_tag_empty and tag in self.library.tags and not is_protected:
                 del self.library.tags[tag]
 
         del self._registry[name]

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -28,7 +28,6 @@ class NotRegistered(Exception):
     pass
 
 
-
 # Why do we store the tags with the component?
 #
 # Each component may be associated with two template tags - One for "block"
@@ -149,7 +148,7 @@ class ComponentRegistry:
 
         # Keep track of which components use which tags, because multiple components may
         # use the same tag.
-        for tag in entry.tags:    
+        for tag in entry.tags:
             if tag not in self._tags:
                 self._tags[tag] = set()
             self._tags[tag].add(name)

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -229,7 +229,6 @@ class ComponentRegistry:
         self._tags = {}
 
 
-
 # This variable represents the global component registry
 registry: ComponentRegistry = ComponentRegistry()
 """

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -1,9 +1,13 @@
-from typing import TYPE_CHECKING, Callable, Dict, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Dict, List, NamedTuple, Optional, Set, Type, TypeVar
+
+from django.template import Library
+
+from django_components.tag_formatter import get_component_tag_formatter
 
 if TYPE_CHECKING:
-    from django_components import component
+    from django_components.component import Component
 
-_TC = TypeVar("_TC", bound=Type["component.Component"])
+_TComp = TypeVar("_TComp", bound=Type["Component"])
 
 
 class AlreadyRegistered(Exception):
@@ -14,49 +18,291 @@ class NotRegistered(Exception):
     pass
 
 
-class ComponentRegistry:
-    def __init__(self) -> None:
-        self._registry: Dict[str, Type["component.Component"]] = {}  # component name -> component_class mapping
+# Why is `tags` a list?
+#
+# Each component may be associated with two template tags - One for "block"
+# and one for "inline" usage. E.g. in the following snippets, the template
+# tags are `component` and `#component`:
+#
+# `{% component "abc" %}{% endcomponent %}`
+# `{% #component "abc" %}`
+#
+# While `endcomponent` also looks like a template tag, we don't have to register
+# it, because it simply marks the end of body.
+#
+# Moreover, with the component tag formatter (configurable tags per component class),
+# each component may have a unique set of template tags.
+class ComponentRegistryEntry(NamedTuple):
+    cls: Type["Component"]
+    tags: List[str]
 
-    def register(self, name: str, component: Type["component.Component"]) -> None:
+
+class ComponentRegistry:
+    """
+    Manages which components can be used in the template tags.
+
+    Each ComponentRegistry instance is associated with an instance
+    of Django's Library. So when you register or unregister a component
+    to/from a component registry, behind the scenes the registry
+    automatically adds/removes the component's template tag to/from
+    the Library.
+
+    The Library instance can be set at instantiation. If omitted, then
+    the default Library instance from django_components is used. The
+    Library instance can be accessed under `library` attribute.
+
+    Example:
+
+    ```py
+    # Use with default Library
+    registry = ComponentRegistry()
+
+    # Or a custom one
+    my_lib = Library()
+    registry = ComponentRegistry(library=my_lib)
+
+    # Usage
+    registry.register("button", ButtonComponent)
+    registry.register("card", CardComponent)
+    registry.all()
+    registry.clear()
+    registry.get()
+    ```
+    """
+
+    def __init__(self, library: Optional[Library] = None) -> None:
+        self._registry: Dict[str, ComponentRegistryEntry] = {}  # component name -> component_entry mapping
+        self._tags: Dict[str, Set[str]] = {}  # tag -> list[component names]
+        self._library = library
+
+    @property
+    def library(self) -> Library:
+        """
+        The template tag library with which the component registry is associated.
+        """
+        # Use the default library if none was passed
+        if self._library is not None:
+            lib = self._library
+        else:
+            from django_components.templatetags.component_tags import register as tag_library
+
+            lib = self._library = tag_library
+        return lib
+
+    def register(self, name: str, component: Type["Component"]) -> None:
+        """
+        Register a component with this registry under the given name.
+
+        A component MUST be registered before it can be used in a template such as:
+        ```django
+        {% component "my_comp" %}{% endcomponent %}
+        ```
+
+        Raises `AlreadyRegistered` if a different component was already registered
+        under the same name.
+
+        Example:
+
+        ```py
+        registry.register("button", ButtonComponent)
+        ```
+        """
         existing_component = self._registry.get(name)
-        if existing_component and existing_component._class_hash != component._class_hash:
+        if existing_component and existing_component.cls._class_hash != component._class_hash:
             raise AlreadyRegistered('The component "%s" has already been registered' % name)
-        self._registry[name] = component
+
+        used_tags = self._register_to_library(name)
+
+        # Keep track of which components use which tags, because multiple components may
+        # use the same tag.
+        for tag in used_tags:
+            if tag not in self._tags:
+                self._tags[tag] = set()
+            self._tags[tag].add(name)
+
+        self._registry[name] = ComponentRegistryEntry(cls=component, tags=used_tags)
 
     def unregister(self, name: str) -> None:
+        """
+        Unlinks a previously-registered component from the registry under the given name.
+
+        Once a component is unregistered, it CANNOT be used in a template anymore.
+        Following would raise an error:
+        ```django
+        {% component "my_comp" %}{% endcomponent %}
+        ```
+
+        Raises `NotRegistered` if the given name is not registered.
+
+        Example:
+
+        ```py
+        # First register component
+        registry.register("button", ButtonComponent)
+        # Then unregister
+        registry.unregister("button")
+        ```
+        """
+        # Validate
         self.get(name)
+
+        entry = self._registry[name]
+
+        # Unregister the tag from library if this was the last component using this tag
+        for tag in entry.tags:
+            # Unlink component from tag
+            self._tags[tag].remove(name)
+
+            # Cleanup
+            is_tag_empty = not len(self._tags[tag])
+            if is_tag_empty:
+                del self._tags[tag]
+
+            # Unregister the tag from library if this was the last component using this tag
+            if is_tag_empty and tag in self.library.tags:
+                del self.library.tags[tag]
 
         del self._registry[name]
 
-    def get(self, name: str) -> Type["component.Component"]:
+    def get(self, name: str) -> Type["Component"]:
+        """
+        Retrieve a component class registered under the given name.
+
+        Raises `NotRegistered` if the given name is not registered.
+
+        Example:
+
+        ```py
+        # First register component
+        registry.register("button", ButtonComponent)
+        # Then get
+        registry.get("button")
+        # > ButtonComponent
+        ```
+        """
         if name not in self._registry:
             raise NotRegistered('The component "%s" is not registered' % name)
 
-        return self._registry[name]
+        return self._registry[name].cls
 
-    def all(self) -> Dict[str, Type["component.Component"]]:
-        return self._registry
+    def all(self) -> Dict[str, Type["Component"]]:
+        """
+        Retrieve all registered component classes.
+
+        Example:
+
+        ```py
+        # First register components
+        registry.register("button", ButtonComponent)
+        registry.register("card", CardComponent)
+        # Then get all
+        registry.all()
+        # > {
+        # >   "button": ButtonComponent,
+        # >   "card": CardComponent,
+        # > }
+        ```
+        """
+        comps = {key: entry.cls for key, entry in self._registry.items()}
+        return comps
 
     def clear(self) -> None:
+        """
+        Clears the registry, unregistering all components.
+
+        Example:
+
+        ```py
+        # First register components
+        registry.register("button", ButtonComponent)
+        registry.register("card", CardComponent)
+        # Then clear
+        registry.clear()
+        # Then get all
+        registry.all()
+        # > {}
+        ```
+        """
+        all_comp_names = list(self._registry.keys())
+        for comp_name in all_comp_names:
+            self.unregister(comp_name)
+
         self._registry = {}
+        self._tags = {}
+
+    def _register_to_library(self, comp_name: str) -> List[str]:
+        from django_components.templatetags.component_tags import (
+            create_block_component_tag,
+            create_inline_component_tag,
+        )
+
+        formatter = get_component_tag_formatter()
+
+        # register the inline tag
+        inline_tag = formatter.safe_format_inline_tag(comp_name)
+        self.library.tag(inline_tag, create_inline_component_tag)
+
+        # register the block tag
+        block_tag = formatter.safe_format_block_start_tag(comp_name)
+        self.library.tag(block_tag, create_block_component_tag)
+
+        used_tags = [inline_tag, block_tag]
+        return used_tags
 
 
 # This variable represents the global component registry
 registry: ComponentRegistry = ComponentRegistry()
+"""
+The default and global component registry. Use this instance to directly
+register or remove components:
+
+```py
+# Register components
+registry.register("button", ButtonComponent)
+registry.register("card", CardComponent)
+# Get single
+registry.get("button")
+# Get all
+registry.all()
+# Unregister single
+registry.unregister("button")
+# Unregister all
+registry.clear()
+```
+"""
+
+# NOTE: Aliased so that the arg to `@register` can also be called `registry`
+_the_registry = registry
 
 
-def register(name: str) -> Callable[[_TC], _TC]:
-    """Class decorator to register a component.
+def register(name: str, registry: Optional[ComponentRegistry] = None) -> Callable[[_TComp], _TComp]:
+    """
+    Class decorator to register a component.
 
     Usage:
 
+    ```py
     @register("my_component")
-    class MyComponent(component.Component):
+    class MyComponent(Component):
         ...
-    """
+    ```
 
-    def decorator(component: _TC) -> _TC:
+    Optionally specify which `ComponentRegistry` the component should be registered to by
+    setting the `registry` kwarg:
+
+    ```py
+    my_lib = django.template.Library()
+    my_reg = ComponentRegistry(library=my_lib)
+
+    @register("my_component", registry=my_reg)
+    class MyComponent(Component):
+        ...
+    ```
+    """
+    if registry is None:
+        registry = _the_registry
+
+    def decorator(component: _TComp) -> _TComp:
         registry.register(name=name, component=component)
         return component
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -73,14 +73,11 @@ class AppendAttributesTest(BaseTestCase):
 
 
 class HtmlAttrsTests(BaseTestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.template_str: types.django_html = """
-            {% load component_tags %}
-            {% component "test" attrs:@click.stop="dispatch('click_event')" attrs:x-data="{hello: 'world'}" attrs:class=class_var %}
-            {% endcomponent %}
-        """  # noqa: E501
+    template_str: types.django_html = """
+        {% load component_tags %}
+        {% component "test" attrs:@click.stop="dispatch('click_event')" attrs:x-data="{hello: 'world'}" attrs:class=class_var %}
+        {% endcomponent %}
+    """  # noqa: E501
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_tag_positional_args(self):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -615,10 +615,6 @@ class ContextVarsIsFilledTests(BaseTestCase):
         )
         registry.register("negated_conditional_slot", self.ComponentWithNegatedConditionalSlot)
 
-    def tearDown(self) -> None:
-        super().tearDown()
-        registry.clear()
-
     @parametrize_context_behavior(["django", "isolated"])
     def test_is_filled_vars(self):
         template: types.django_html = """

--- a/tests/test_dependency_rendering.py
+++ b/tests/test_dependency_rendering.py
@@ -67,10 +67,6 @@ class MultistyleComponent(Component):
 
 @override_settings(COMPONENTS={"RENDER_DEPENDENCIES": True})
 class ComponentMediaRenderingTests(BaseTestCase):
-    def setUp(self):
-        # NOTE: registry is global, so need to clear before each test
-        registry.clear()
-
     def test_no_dependencies_when_no_components_used(self):
         registry.register(name="test", component=SimpleComponent)
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -79,7 +79,7 @@ class ComponentRegistryTest(unittest.TestCase):
             self.registry._tags,
             {
                 "component": {"testcomponent", "testcomponent2"},
-            }
+            },
         )
 
         self.assertIn("component", self.registry.library.tags)
@@ -91,7 +91,7 @@ class ComponentRegistryTest(unittest.TestCase):
             self.registry._tags,
             {
                 "component": {"testcomponent2"},
-            }
+            },
         )
 
         self.assertIn("component", self.registry.library.tags)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,7 @@
 import unittest
 
+from django.template import Library
+
 from django_components import AlreadyRegistered, Component, ComponentRegistry, NotRegistered, register, registry
 
 from .django_test_setup import setup_test_config
@@ -31,6 +33,22 @@ class ComponentRegistryTest(unittest.TestCase):
 
         self.assertEqual(registry.get("decorated_component"), TestComponent)
 
+    def test_register_class_decorator_custom_registry(self):
+        registry.clear()
+
+        my_lib = Library()
+        my_reg = ComponentRegistry(library=my_lib)
+
+        self.assertDictEqual(my_reg.all(), {})
+        self.assertDictEqual(registry.all(), {})
+
+        @register("decorated_component", registry=my_reg)
+        class TestComponent(Component):
+            pass
+
+        self.assertDictEqual(my_reg.all(), {"decorated_component": TestComponent})
+        self.assertDictEqual(registry.all(), {})
+
     def test_simple_register(self):
         self.registry.register(name="testcomponent", component=MockComponent)
         self.assertEqual(self.registry.all(), {"testcomponent": MockComponent})
@@ -45,6 +63,41 @@ class ComponentRegistryTest(unittest.TestCase):
                 "testcomponent2": MockComponent,
             },
         )
+
+    def test_unregisters_only_unused_tags(self):
+        self.assertDictEqual(self.registry._tags, {})
+        self.assertNotIn("component", self.registry.library.tags)
+        self.assertNotIn("#component", self.registry.library.tags)
+
+        # Register two components that use the same tag
+        self.registry.register(name="testcomponent", component=MockComponent)
+        self.registry.register(name="testcomponent2", component=MockComponent)
+
+        self.assertDictEqual(self.registry._tags, {
+            "component": {"testcomponent", "testcomponent2"},
+            "#component": {"testcomponent", "testcomponent2"},
+        })
+
+        self.assertIn("component", self.registry.library.tags)
+        self.assertIn("#component", self.registry.library.tags)
+
+        # Unregister only one of the components. The tags should remain
+        self.registry.unregister(name="testcomponent")
+
+        self.assertDictEqual(self.registry._tags, {
+            "component": {"testcomponent2"},
+            "#component": {"testcomponent2"},
+        })
+
+        self.assertIn("component", self.registry.library.tags)
+        self.assertIn("#component", self.registry.library.tags)
+
+        # Unregister the second components. The tags should be removed
+        self.registry.unregister(name="testcomponent2")
+
+        self.assertDictEqual(self.registry._tags, {})
+        self.assertNotIn("component", self.registry.library.tags)
+        self.assertNotIn("#component", self.registry.library.tags)
 
     def test_prevent_registering_different_components_with_the_same_name(self):
         self.registry.register(name="testcomponent", component=MockComponent)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -73,10 +73,13 @@ class ComponentRegistryTest(unittest.TestCase):
         self.registry.register(name="testcomponent", component=MockComponent)
         self.registry.register(name="testcomponent2", component=MockComponent)
 
-        self.assertDictEqual(self.registry._tags, {
-            "component": {"testcomponent", "testcomponent2"},
-            "#component": {"testcomponent", "testcomponent2"},
-        })
+        self.assertDictEqual(
+            self.registry._tags,
+            {
+                "component": {"testcomponent", "testcomponent2"},
+                "#component": {"testcomponent", "testcomponent2"},
+            },
+        )
 
         self.assertIn("component", self.registry.library.tags)
         self.assertIn("#component", self.registry.library.tags)
@@ -84,10 +87,13 @@ class ComponentRegistryTest(unittest.TestCase):
         # Unregister only one of the components. The tags should remain
         self.registry.unregister(name="testcomponent")
 
-        self.assertDictEqual(self.registry._tags, {
-            "component": {"testcomponent2"},
-            "#component": {"testcomponent2"},
-        })
+        self.assertDictEqual(
+            self.registry._tags,
+            {
+                "component": {"testcomponent2"},
+                "#component": {"testcomponent2"},
+            },
+        )
 
         self.assertIn("component", self.registry.library.tags)
         self.assertIn("#component", self.registry.library.tags)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -78,6 +78,7 @@ class ComponentRegistryTest(unittest.TestCase):
         self.assertDictEqual(
             self.registry._tags,
             {
+                "#component": {"testcomponent", "testcomponent2"},
                 "component": {"testcomponent", "testcomponent2"},
             },
         )
@@ -90,6 +91,7 @@ class ComponentRegistryTest(unittest.TestCase):
         self.assertDictEqual(
             self.registry._tags,
             {
+                "#component": {"testcomponent2"},
                 "component": {"testcomponent2"},
             },
         )

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -25,6 +25,7 @@ class TemplateInstrumentationTest(BaseTestCase):
     saved_render_method: Callable  # Assigned during setup.
 
     def tearDown(self):
+        super().tearDown()
         Template._render = self.saved_render_method
 
     def setUp(self):
@@ -92,14 +93,6 @@ class TemplateInstrumentationTest(BaseTestCase):
 
 
 class BlockCompatTests(BaseTestCase):
-    def setUp(self):
-        registry.clear()
-        super().setUp()
-
-    def tearDown(self):
-        super().tearDown()
-        registry.clear()
-
     @parametrize_context_behavior(["django", "isolated"])
     def test_slots_inside_extends(self):
         registry.register("slotted_component", SlottedComponent)

--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -32,10 +32,6 @@ class SlottedComponentWithContext(SlottedComponent):
 
 
 class ComponentSlottedTemplateTagTest(BaseTestCase):
-    def setUp(self):
-        # NOTE: registry is global, so need to clear before each test
-        registry.clear()
-
     @parametrize_context_behavior(["django", "isolated"])
     def test_slotted_template_basic(self):
         registry.register(name="test1", component=SlottedComponent)
@@ -477,10 +473,6 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
 
 
 class SlottedTemplateRegressionTests(BaseTestCase):
-    def setUp(self):
-        # NOTE: registry is global, so need to clear before each test
-        registry.clear()
-
     @parametrize_context_behavior(["django", "isolated"])
     def test_slotted_template_that_uses_missing_variable(self):
         @register("test")
@@ -517,12 +509,7 @@ class SlottedTemplateRegressionTests(BaseTestCase):
 class SlotDefaultTests(BaseTestCase):
     def setUp(self):
         super().setUp()
-        registry.clear()
         registry.register("test", SlottedComponent)
-
-    def tearDown(self):
-        super().tearDown()
-        registry.clear()
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_basic(self):
@@ -1114,10 +1101,6 @@ class SlotFillTemplateSyntaxErrorTests(BaseTestCase):
     def setUp(self):
         super().setUp()
         registry.register("test", SlottedComponent)
-
-    def tearDown(self):
-        super().tearDown()
-        registry.clear()
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_fill_with_no_parent_is_error(self):

--- a/tests/test_templatetags_templating.py
+++ b/tests/test_templatetags_templating.py
@@ -178,12 +178,7 @@ class ConditionalSlotTests(BaseTestCase):
 
     def setUp(self):
         super().setUp()
-        registry.clear()
         registry.register("test", self.ConditionalComponent)
-
-    def tearDown(self):
-        super().tearDown()
-        registry.clear()
 
     @parametrize_context_behavior(["django", "isolated"])
     def test_no_content_if_branches_are_false(self):
@@ -259,9 +254,6 @@ class SlotIterationTest(BaseTestCase):
             return {
                 "objects": objects,
             }
-
-    def setUp(self):
-        registry.clear()
 
     # NOTE: Second arg in tuple is expected result. In isolated mode, loops should NOT leak.
     @parametrize_context_behavior(
@@ -626,10 +618,6 @@ class ComponentNestingTests(BaseTestCase):
         registry.register("calendar", self.CalendarComponent)
         registry.register("complex_child", self.ComplexChildComponent)
         registry.register("complex_parent", self.ComplexParentComponent)
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        registry.clear()
 
     # NOTE: Second arg in tuple are expected names in nested fills. In "django" mode,
     # the value should be overridden by the component, while in "isolated" it should

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -20,13 +20,6 @@ middleware = ComponentDependencyMiddleware(get_response=lambda _: response_stash
 
 
 class BaseTestCase(SimpleTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        # Ensure that the module that defines the template tags is executed again after import
-        if "django_components.templatetags.component_tags" in sys.modules:
-            del sys.modules["django_components.templatetags.component_tags"]
-        registry._library = None
-
     def tearDown(self) -> None:
         super().tearDown()
         registry.clear()

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -20,6 +20,13 @@ middleware = ComponentDependencyMiddleware(get_response=lambda _: response_stash
 
 
 class BaseTestCase(SimpleTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        # Ensure that the module that defines the template tags is executed again after import
+        if "django_components.templatetags.component_tags" in sys.modules:
+            del sys.modules["django_components.templatetags.component_tags"]
+        registry._library = None
+
     def tearDown(self) -> None:
         super().tearDown()
         registry.clear()


### PR DESCRIPTION
Changes:
- Document how `ComponentRegistry` works
- `ComponentRegistry()` accepts an optional `library` kwarg
- `@register` decorator accepts an optional `registry` kwarg
- Preparation for custom component template tags:
	- There can be multiple template tags used for rendering the same component (for the "block" and "inline" forms)
	- When user registers a component with not-seen-before template tags, the tags are automatically registered
  into to `library`. And when the last component that uses those tags is unregistered,
  the tag is removed from `library`.

This is the last step before https://github.com/EmilStenstrom/django-components/issues/527