### PR TITLE
fix: Allow `None` for attrs in `html_attrs` tag

### DIFF
--- a/src/django_components/attributes.py
+++ b/src/django_components/attributes.py
@@ -33,8 +33,8 @@ class HtmlAttrsNode(Node):
             resolved_value = safe_resolve(value, context)
             append_attrs.append((key, resolved_value))
 
-        defaults = safe_resolve(self.defaults, context) if self.defaults else {}
-        attrs = safe_resolve(self.attributes, context) if self.attributes else {}
+        defaults = safe_resolve(self.defaults, context) or {} if self.defaults else {}
+        attrs = safe_resolve(self.attributes, context) or {} if self.attributes else {}
 
         # Merge it
         final_attrs = {**defaults, **attrs}

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -360,3 +360,31 @@ class HtmlAttrsTests(BaseTestCase):
             """,
         )
         self.assertNotIn("override-me", rendered)
+
+    def test_tag_null_attrs_and_defaults(self):
+        @register("test")
+        class AttrsComponent(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                <div {% html_attrs attrs defaults %}>
+                    content
+                </div>
+            """
+
+            def get_context_data(self, *args, attrs):
+                return {
+                    "attrs": None,
+                    "defaults": None,
+                }
+
+        template = Template(self.template_str)
+        rendered = template.render(Context({"class_var": "padding-top-8"}))
+        self.assertHTMLEqual(
+            rendered,
+            """
+            <div >
+                content
+            </div>
+            """,
+        )
+        self.assertNotIn("override-me", rendered)


### PR DESCRIPTION
Tiny error that I just came across in `{% html_attrs %}` as I upgraded from v0.84 to v0.90.

In v0.84, `html_attrs` allowed `attrs` and `defaults` to be `None`, but it's not the case in v0.90.