### PR TITLE
fix: mypy checking with django plugin is broken

### DIFF
--- a/src/django_components/types.py
+++ b/src/django_components/types.py
@@ -14,12 +14,12 @@ except ImportError:
         def __repr__(self) -> str:
             return f"Annotated[{self.type_}, {self.metadata[0]!r}, {self.metadata[1]!r}]"
 
-        def __getitem__(self, params: Any) -> "Annotated":  # type: ignore
+        def __getitem__(self, params: Any) -> "Annotated[Any, Any, Any]":  # type: ignore
             if not isinstance(params, tuple):
                 params = (params,)
             return Annotated(self.type_, *params, **self.metadata[1])  # type: ignore
 
-        def __class_getitem__(self, *params: Any) -> "Annotated":  # type: ignore
+        def __class_getitem__(self, *params: Any) -> "Annotated[Any, Any, Any]":  # type: ignore
             return Annotated(*params)  # type: ignore
 
 


### PR DESCRIPTION
The mypy check with Django plugin breaks with the following error:

```
Traceback (most recent call last):
  File "mypy/semanal.py", line 7092, in accept
  File "mypy/nodes.py", line 819, in accept
  File "mypy/semanal.py", line 874, in visit_func_def
  File "mypy/semanal.py", line 916, in analyze_func_def
  File "mypy/typeanal.py", line 1098, in visit_callable_type
  File "mypy/typeanal.py", line 1774, in anal_type
  File "mypy/types.py", line 2707, in accept
  File "mypy/types.py", line 944, in accept
  File "mypy/typeanal.py", line 281, in visit_unbound_type
  File "mypy/typeanal.py", line 334, in visit_unbound_type_nonoptional
  File "/home/okipa/.local/share/virtualenvs/okipa-lk14Xlau/lib/python3.12/site-packages/mypy_django_plugin/transformers/models.py", line 1067, in handle_annotated_type
    type_arg = ctx.api.analyze_type(args[0])
                                    ~~~~^^^
IndexError: tuple index out of range
```

This change solves the problem