### PR TITLE
Increase minimum coverage to 97%

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ changedir = {toxinidir}
 deps = pytest-coverage
 commands =
   coverage run --branch -m pytest
-  coverage report -m --fail-under=93
+  coverage report -m --fail-under=97
 
 [testenv:mypy]
 changedir = {toxinidir}


### PR DESCRIPTION
Juro has done a great job increasing the test coverage for new code. 

This pull request increases the minimum coverage requirement to 97%. The `coverage report` command has been updated to fail if the coverage falls below this threshold.