### PR TITLE
feat: allow different template settings for ComponentRegistries

### DIFF
--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -5,6 +5,7 @@ import django
 
 # Public API
 # isort: off
+from django_components.app_settings import ContextBehavior as ContextBehavior
 from django_components.autodiscover import (
     autodiscover as autodiscover,
     import_libraries as import_libraries,
@@ -17,6 +18,7 @@ from django_components.component_registry import (
     AlreadyRegistered as AlreadyRegistered,
     ComponentRegistry as ComponentRegistry,
     NotRegistered as NotRegistered,
+    RegistrySettings as RegistrySettings,
     register as register,
     registry as registry,
 )

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -33,7 +33,8 @@ from django.views import View
 
 from django_components.app_settings import ContextBehavior
 from django_components.component_media import ComponentMediaInput, MediaMeta
-from django_components.component_registry import ComponentRegistry, registry as registry_
+from django_components.component_registry import ComponentRegistry
+from django_components.component_registry import registry as registry_
 from django_components.context import (
     _FILLED_SLOTS_CONTENT_CONTEXT_KEY,
     _PARENT_COMP_CONTEXT_KEY,
@@ -173,7 +174,7 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
         component_id: Optional[str] = None,
         outer_context: Optional[Context] = None,
         fill_content: Optional[Dict[str, FillContent]] = None,
-        registry: Optional[ComponentRegistry] = None,
+        registry: Optional[ComponentRegistry] = None,  # noqa F811
     ):
         # When user first instantiates the component class before calling
         # `render` or `render_to_response`, then we want to allow the render
@@ -603,7 +604,7 @@ class ComponentNode(BaseNode):
         name: str,
         args: List[Expression],
         kwargs: RuntimeKwargs,
-        registry: ComponentRegistry,
+        registry: ComponentRegistry,  # noqa F811
         isolated_context: bool = False,
         fill_nodes: Optional[List[FillNode]] = None,
         node_id: Optional[str] = None,

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -545,7 +545,6 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
                     _ROOT_CTX_CONTEXT_KEY: self.outer_context,
                     _FILLED_SLOTS_CONTENT_CONTEXT_KEY: updated_slots,
                     _REGISTRY_CONTEXT_KEY: self.registry,
-
                     # NOTE: Public API for variables accessible from within a component's template
                     # See https://github.com/EmilStenstrom/django-components/issues/280#issuecomment-2081180940
                     "component_vars": {

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -31,11 +31,13 @@ from django.utils.html import conditional_escape
 from django.utils.safestring import SafeString, mark_safe
 from django.views import View
 
+from django_components.app_settings import ContextBehavior
 from django_components.component_media import ComponentMediaInput, MediaMeta
-from django_components.component_registry import registry
+from django_components.component_registry import ComponentRegistry, registry as registry_
 from django_components.context import (
     _FILLED_SLOTS_CONTENT_CONTEXT_KEY,
     _PARENT_COMP_CONTEXT_KEY,
+    _REGISTRY_CONTEXT_KEY,
     _ROOT_CTX_CONTEXT_KEY,
     get_injected_context_var,
     make_isolated_context_copy,
@@ -70,6 +72,7 @@ from django_components.component_registry import registry as registry  # NOQA
 # isort: on
 
 RENDERED_COMMENT_TEMPLATE = "<!-- _RENDERED {name} -->"
+COMP_ONLY_FLAG = "only"
 
 # Define TypeVars for args and kwargs
 ArgsType = TypeVar("ArgsType", bound=tuple, contravariant=True)
@@ -170,6 +173,7 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
         component_id: Optional[str] = None,
         outer_context: Optional[Context] = None,
         fill_content: Optional[Dict[str, FillContent]] = None,
+        registry: Optional[ComponentRegistry] = None,
     ):
         # When user first instantiates the component class before calling
         # `render` or `render_to_response`, then we want to allow the render
@@ -189,6 +193,7 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
         self.outer_context: Context = outer_context or Context()
         self.fill_content = fill_content or {}
         self.component_id = component_id or gen_id()
+        self.registry = registry or registry_
         self._render_stack: Deque[RenderInput[ArgsType, KwargsType, SlotsType]] = deque()
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
@@ -535,8 +540,11 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
 
             with context.update(
                 {
+                    # Private context fields
                     _ROOT_CTX_CONTEXT_KEY: self.outer_context,
                     _FILLED_SLOTS_CONTENT_CONTEXT_KEY: updated_slots,
+                    _REGISTRY_CONTEXT_KEY: self.registry,
+
                     # NOTE: Public API for variables accessible from within a component's template
                     # See https://github.com/EmilStenstrom/django-components/issues/280#issuecomment-2081180940
                     "component_vars": {
@@ -595,6 +603,7 @@ class ComponentNode(BaseNode):
         name: str,
         args: List[Expression],
         kwargs: RuntimeKwargs,
+        registry: ComponentRegistry,
         isolated_context: bool = False,
         fill_nodes: Optional[List[FillNode]] = None,
         node_id: Optional[str] = None,
@@ -604,6 +613,7 @@ class ComponentNode(BaseNode):
         self.name = name
         self.isolated_context = isolated_context
         self.fill_nodes = fill_nodes or []
+        self.registry = registry
 
     def __repr__(self) -> str:
         return "<ComponentNode: {}. Contents: {!r}>".format(
@@ -614,7 +624,7 @@ class ComponentNode(BaseNode):
     def render(self, context: Context) -> str:
         trace_msg("RENDR", "COMP", self.name, self.node_id)
 
-        component_cls: Type[Component] = registry.get(self.name)
+        component_cls: Type[Component] = self.registry.get(self.name)
 
         # Resolve FilterExpressions and Variables that were passed as args to the
         # component, then call component's context method
@@ -639,10 +649,11 @@ class ComponentNode(BaseNode):
             outer_context=context,
             fill_content=fill_content,
             component_id=self.node_id,
+            registry=self.registry,
         )
 
         # Prevent outer context from leaking into the template of the component
-        if self.isolated_context:
+        if self.isolated_context or self.registry.settings.CONTEXT_BEHAVIOR == ContextBehavior.ISOLATED:
             context = make_isolated_context_copy(context)
 
         output = component._render(

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -37,7 +37,6 @@ class ComponentRegistryEntry(NamedTuple):
 class RegistrySettings(NamedTuple):
     CONTEXT_BEHAVIOR: ContextBehavior
     TAG_FORMATTER: Union["TagFormatterABC", str]
-    TEMPLATE_CACHE_SIZE: int
 
 
 class ComponentRegistry:
@@ -114,7 +113,6 @@ class ComponentRegistry:
             self._settings = lambda _: RegistrySettings(
                 CONTEXT_BEHAVIOR=app_settings.CONTEXT_BEHAVIOR,
                 TAG_FORMATTER=app_settings.TAG_FORMATTER,
-                TEMPLATE_CACHE_SIZE=app_settings.TEMPLATE_CACHE_SIZE,
             )
             settings = self._settings(self)
         return settings

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -120,8 +120,7 @@ class ComponentRegistry:
         # NOTE: We allow the settings to be given as a getter function
         # so the settings can respond to changes.
         # So we wrapp that in our getter, which assigns default values from the settings.
-        elif self._settings_input:
-
+        else:
             def get_settings() -> InternalRegistrySettings:
                 if callable(self._settings_input):
                     settings_input: Optional[RegistrySettings] = self._settings_input(self)
@@ -129,8 +128,7 @@ class ComponentRegistry:
                     settings_input = self._settings_input
 
                 return InternalRegistrySettings(
-                    CONTEXT_BEHAVIOR=(settings_input and settings_input.CONTEXT_BEHAVIOR)
-                    or app_settings.CONTEXT_BEHAVIOR,
+                    CONTEXT_BEHAVIOR=(settings_input and settings_input.CONTEXT_BEHAVIOR) or app_settings.CONTEXT_BEHAVIOR,
                     TAG_FORMATTER=(settings_input and settings_input.TAG_FORMATTER) or app_settings.TAG_FORMATTER,
                 )
 

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -121,6 +121,7 @@ class ComponentRegistry:
         # so the settings can respond to changes.
         # So we wrapp that in our getter, which assigns default values from the settings.
         elif self._settings_input:
+
             def get_settings() -> InternalRegistrySettings:
                 if callable(self._settings_input):
                     settings_input: Optional[RegistrySettings] = self._settings_input(self)
@@ -128,7 +129,8 @@ class ComponentRegistry:
                     settings_input = self._settings_input
 
                 return InternalRegistrySettings(
-                    CONTEXT_BEHAVIOR=(settings_input and settings_input.CONTEXT_BEHAVIOR) or app_settings.CONTEXT_BEHAVIOR,
+                    CONTEXT_BEHAVIOR=(settings_input and settings_input.CONTEXT_BEHAVIOR)
+                    or app_settings.CONTEXT_BEHAVIOR,
                     TAG_FORMATTER=(settings_input and settings_input.TAG_FORMATTER) or app_settings.TAG_FORMATTER,
                 )
 

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -121,6 +121,7 @@ class ComponentRegistry:
         # so the settings can respond to changes.
         # So we wrapp that in our getter, which assigns default values from the settings.
         else:
+
             def get_settings() -> InternalRegistrySettings:
                 if callable(self._settings_input):
                     settings_input: Optional[RegistrySettings] = self._settings_input(self)
@@ -128,7 +129,8 @@ class ComponentRegistry:
                     settings_input = self._settings_input
 
                 return InternalRegistrySettings(
-                    CONTEXT_BEHAVIOR=(settings_input and settings_input.CONTEXT_BEHAVIOR) or app_settings.CONTEXT_BEHAVIOR,
+                    CONTEXT_BEHAVIOR=(settings_input and settings_input.CONTEXT_BEHAVIOR)
+                    or app_settings.CONTEXT_BEHAVIOR,
                     TAG_FORMATTER=(settings_input and settings_input.TAG_FORMATTER) or app_settings.TAG_FORMATTER,
                 )
 

--- a/src/django_components/context.py
+++ b/src/django_components/context.py
@@ -14,6 +14,7 @@ from django_components.utils import find_last_index
 
 _FILLED_SLOTS_CONTENT_CONTEXT_KEY = "_DJANGO_COMPONENTS_FILLED_SLOTS"
 _ROOT_CTX_CONTEXT_KEY = "_DJANGO_COMPONENTS_ROOT_CTX"
+_REGISTRY_CONTEXT_KEY = "_DJANGO_COMPONENTS_REGISTRY"
 _PARENT_COMP_CONTEXT_KEY = "_DJANGO_COMPONENTS_PARENT_COMP"
 _CURRENT_COMP_CONTEXT_KEY = "_DJANGO_COMPONENTS_CURRENT_COMP"
 _INJECT_CONTEXT_KEY_PREFIX = "_DJANGO_COMPONENTS_INJECT__"
@@ -38,6 +39,7 @@ def make_isolated_context_copy(context: Context) -> Context:
 
     # Pass through our internal keys
     context_copy[_FILLED_SLOTS_CONTENT_CONTEXT_KEY] = context.get(_FILLED_SLOTS_CONTENT_CONTEXT_KEY, {})
+    context_copy[_REGISTRY_CONTEXT_KEY] = context.get(_REGISTRY_CONTEXT_KEY, None)
     if _ROOT_CTX_CONTEXT_KEY in context:
         context_copy[_ROOT_CTX_CONTEXT_KEY] = context[_ROOT_CTX_CONTEXT_KEY]
 

--- a/src/django_components/library.py
+++ b/src/django_components/library.py
@@ -1,6 +1,6 @@
 """Module for interfacing with Django's Library (`django.template.library`)"""
 
-from typing import Callable, List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from django.template.base import Node, Parser, Token
 from django.template.library import Library

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -3,7 +3,22 @@ import json
 import re
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, List, Mapping, NamedTuple, Optional, Protocol, Set, Tuple, Type, TypeVar, Union, TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generic,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Protocol,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from django.template import Context, Template
 from django.template.base import FilterExpression, Node, NodeList, Parser, TextNode

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -3,7 +3,7 @@ import json
 import re
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, List, Mapping, NamedTuple, Optional, Protocol, Set, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, Generic, List, Mapping, NamedTuple, Optional, Protocol, Set, Tuple, Type, TypeVar, Union, TYPE_CHECKING
 
 from django.template import Context, Template
 from django.template.base import FilterExpression, Node, NodeList, Parser, TextNode
@@ -11,15 +11,19 @@ from django.template.defaulttags import CommentNode
 from django.template.exceptions import TemplateSyntaxError
 from django.utils.safestring import SafeString, mark_safe
 
-from django_components.app_settings import ContextBehavior, app_settings
+from django_components.app_settings import ContextBehavior
 from django_components.context import (
     _FILLED_SLOTS_CONTENT_CONTEXT_KEY,
     _INJECT_CONTEXT_KEY_PREFIX,
+    _REGISTRY_CONTEXT_KEY,
     _ROOT_CTX_CONTEXT_KEY,
 )
 from django_components.expression import RuntimeKwargs, is_identifier
 from django_components.logger import trace_msg
 from django_components.node import BaseNode, NodeTraverse, nodelist_has_content, walk_nodelist
+
+if TYPE_CHECKING:
+    from django_components.component_registry import ComponentRegistry
 
 TSlotData = TypeVar("TSlotData", bound=Mapping, contravariant=True)
 
@@ -215,12 +219,13 @@ class SlotNode(BaseNode):
         if not slot_fill.is_filled:
             return context
 
-        if app_settings.CONTEXT_BEHAVIOR == ContextBehavior.DJANGO:
+        registry: "ComponentRegistry" = context[_REGISTRY_CONTEXT_KEY]
+        if registry.settings.CONTEXT_BEHAVIOR == ContextBehavior.DJANGO:
             return context
-        elif app_settings.CONTEXT_BEHAVIOR == ContextBehavior.ISOLATED:
+        elif registry.settings.CONTEXT_BEHAVIOR == ContextBehavior.ISOLATED:
             return context[_ROOT_CTX_CONTEXT_KEY]
         else:
-            raise ValueError(f"Unknown value for CONTEXT_BEHAVIOR: '{app_settings.CONTEXT_BEHAVIOR}'")
+            raise ValueError(f"Unknown value for CONTEXT_BEHAVIOR: '{registry.settings.CONTEXT_BEHAVIOR}'")
 
     def resolve_kwargs(
         self,

--- a/src/django_components/tag_formatter.py
+++ b/src/django_components/tag_formatter.py
@@ -1,14 +1,17 @@
 import abc
 import re
-from typing import List, NamedTuple
+from typing import List, NamedTuple, TYPE_CHECKING
 
 from django.template import TemplateSyntaxError
 from django.utils.module_loading import import_string
 
-from django_components.app_settings import app_settings
 from django_components.expression import resolve_string
 from django_components.template_parser import VAR_CHARS
 from django_components.utils import is_str_wrapped_in_quotes
+
+if TYPE_CHECKING:
+    from django_components.component_registry import ComponentRegistry
+
 
 TAG_RE = re.compile(r"^[{chars}]+$".format(chars=VAR_CHARS))
 
@@ -201,10 +204,10 @@ class ShorthandComponentFormatter(TagFormatterABC):
         return TagResult(name, tokens)
 
 
-def get_tag_formatter() -> InternalTagFormatter:
+def get_tag_formatter(registry: "ComponentRegistry") -> InternalTagFormatter:
     """Returns an instance of the currently configured component tag formatter."""
     # Allow users to configure the component TagFormatter
-    formatter_cls_or_str = app_settings.TAG_FORMATTER
+    formatter_cls_or_str = registry.settings.TAG_FORMATTER
 
     if isinstance(formatter_cls_or_str, str):
         tag_formatter: TagFormatterABC = import_string(formatter_cls_or_str)

--- a/src/django_components/tag_formatter.py
+++ b/src/django_components/tag_formatter.py
@@ -1,6 +1,6 @@
 import abc
 import re
-from typing import List, NamedTuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, NamedTuple
 
 from django.template import TemplateSyntaxError
 from django.utils.module_loading import import_string

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -259,7 +259,7 @@ def component(parser: Parser, token: Token, registry: ComponentRegistry, tag_nam
         isolated_context=isolated_context,
         fill_nodes=fill_nodes,
         node_id=tag.id,
-        registry=register,
+        registry=registry,
     )
 
     trace_msg("PARSE", "COMP", result.component_name, tag.id, "...Done!")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -191,9 +191,9 @@ class MultipleComponentRegistriesTest(BaseTestCase):
             {% simple_a variable=123 %}
                 SLOT 123
             {% endsimple_a %}
-            {% component "simple_b" variable=123 %} 
+            {% component "simple_b" variable=123 %}
                 SLOT ABC
-            {% endcomponent %} 
+            {% endcomponent %}
         """
         template = Template(template_str)
 
@@ -203,11 +203,11 @@ class MultipleComponentRegistriesTest(BaseTestCase):
             rendered,
             """
             Variable: <strong>123</strong>
-            Slot: 
+            Slot:
             SLOT 123
 
             Variable: <strong>123</strong>
-            Slot:  
+            Slot:
             SLOT ABC
             """,
         )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -149,7 +149,6 @@ class MultipleComponentRegistriesTest(BaseTestCase):
             settings=RegistrySettings(
                 CONTEXT_BEHAVIOR=ContextBehavior.ISOLATED,
                 TAG_FORMATTER=component_shorthand_formatter,
-                TEMPLATE_CACHE_SIZE=128,
             ),
         )
 
@@ -159,7 +158,6 @@ class MultipleComponentRegistriesTest(BaseTestCase):
             settings=RegistrySettings(
                 CONTEXT_BEHAVIOR=ContextBehavior.DJANGO,
                 TAG_FORMATTER=component_formatter,
-                TEMPLATE_CACHE_SIZE=128,
             ),
         )
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,14 +1,13 @@
 import unittest
 
 from django.template import Context, Engine, Library, Template
-
 from django.test import override_settings
 
 from django_components import (
     AlreadyRegistered,
-    ContextBehavior,
     Component,
     ComponentRegistry,
+    ContextBehavior,
     NotRegistered,
     RegistrySettings,
     TagProtectedError,


### PR DESCRIPTION
Ngl, I'm pretty excited about this! 🦜 

This MR allows template settings (`CONTEXT_BEHAVIOR` and `TAG_FORMATTER`), to be configured per registry / library.

So, assuming that `simple_a` comes from Library A, and `simple_b` comes from Library B, now following is possible:

```django
{% simple_a variable=123 %}
    SLOT 123
{% endsimple_a %}
{% component "simple_b" variable=123 %}
    SLOT ABC
{% endcomponent %}
```

Also:
- Added section on `ComponentRegistry` settings
- Added section on writing, publishing and sharing component libraries

Closes https://github.com/EmilStenstrom/django-components/issues/590

TODO:
- [x] Docs