### PR TITLE
refactor: Fix template caching, expose `cached_template`, Component.template API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3170,6 +3170,26 @@ COMPONENTS = {
 }
 ```
 
+If you want add templates to the cache yourself, you can use `cached_template()`:
+
+```py
+from django_components import cached_template
+
+cached_template("Variable: {{ variable }}")
+
+# You can optionally specify Template class, and other Template inputs:
+class MyTemplate(Template):
+    pass
+
+cached_template(
+    "Variable: {{ variable }}",
+    template_cls=MyTemplate,
+    name=...
+    origin=...
+    engine=...
+)
+```
+
 ### `context_behavior` - Make components isolated (or not)
 
 > NOTE: `context_behavior` and `slot_context_behavior` options were merged in v0.70.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ And this is what gets rendered (plus the CSS and Javascript you've specified):
 - The previously undocumented `get_template` was made private.
 - In it's place, there's a new `get_template`, which supersedes `get_template_string` (will be removed in v1). The new `get_template` is the same as `get_template_string`, except
 it allows to return either a string or a Template instance.
+- You now must use only one of `template`, `get_template`, `template_name`, or `get_template_name`.
 
 **Version 0.96**
 - Run-time type validation for Python 3.11+ - If the `Component` class is typed, e.g. `Component[Args, Kwargs, ...]`, the args, kwargs, slots, and data are validated against the given types. (See [Runtime input validation with types](#runtime-input-validation-with-types))

--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ And this is what gets rendered (plus the CSS and Javascript you've specified):
 
 **Version 0.97**
 - Fixed template caching. You can now also manually create cached templates with [`cached_template()`](#template_cache_size---tune-the-template-cache)
-- `get_template_name` and `get_template_string` were merged into `template_name` and `template`, and old formats will be removed in v1.
-- The undocumented `get_template` was made private.
+- The previously undocumented `get_template` was made private.
+- In it's place, there's a new `get_template`, which supersedes `get_template_string` (will be removed in v1). The new `get_template` is the same as `get_template_string`, except
+it allows to return either a string or a Template instance.
 
 **Version 0.96**
 - Run-time type validation for Python 3.11+ - If the `Component` class is typed, e.g. `Component[Args, Kwargs, ...]`, the args, kwargs, slots, and data are validated against the given types. (See [Runtime input validation with types](#runtime-input-validation-with-types))
@@ -98,7 +99,7 @@ And this is what gets rendered (plus the CSS and Javascript you've specified):
 🚨📢 **Version 0.92**
 - BREAKING CHANGE: `Component` class is no longer a subclass of `View`. To configure the `View` class, set the `Component.View` nested class. HTTP methods like `get` or `post` can still be defined directly on `Component` class, and `Component.as_view()` internally calls `Component.View.as_view()`. (See [Modifying the View class](#modifying-the-view-class))
 
-- The inputs (args, kwargs, slots, context, ...) that you pass to `Component.render()` can be accessed from within `get_context_data`, `template` and `template_name` via `self.input`. (See [Accessing data passed to the component](#accessing-data-passed-to-the-component))
+- The inputs (args, kwargs, slots, context, ...) that you pass to `Component.render()` can be accessed from within `get_context_data`, `get_template` and `get_template_name` via `self.input`. (See [Accessing data passed to the component](#accessing-data-passed-to-the-component))
 
 - Typing: `Component` class supports generics that specify types for `Component.render` (See [Adding type hints with Generics](#adding-type-hints-with-generics))
 
@@ -393,7 +394,7 @@ class Calendar(Component):
     # `template_name` can be relative to dir where `calendar.py` is, or relative to STATICFILES_DIRS
     template_name = "template.html"
     # Or
-    def template_name(context):
+    def get_template_name(context):
         return f"template-{context['name']}.html"
 
     # This component takes one parameter, a date string to show in the template
@@ -1748,8 +1749,8 @@ When you call `Component.render` or `Component.render_to_response`, the inputs t
 
 This means that you can use `self.input` inside:
 - `get_context_data`
-- `template_name`
-- `template`
+- `get_template_name`
+- `get_template`
 
 `self.input` is defined only for the duration of `Component.render`, and raises `RuntimeError` when called outside of this.
 

--- a/sampleproject/components/calendar/calendar.py
+++ b/sampleproject/components/calendar/calendar.py
@@ -9,7 +9,7 @@ class Calendar(Component):
     # `template_name` can be relative to dir where `calendar.py` is, or relative to STATICFILES_DIRS
     template_name = "calendar/calendar.html"
     # Or
-    # def template_name(context):
+    # def get_template_name(context):
     #     return f"template-{context['name']}.html"
 
     # This component takes one parameter, a date string to show in the template
@@ -37,7 +37,7 @@ class CalendarRelative(Component):
     # `template_name` can be relative to dir where `calendar.py` is, or relative to STATICFILES_DIRS
     template_name = "calendar.html"
     # Or
-    # def template_name(context):
+    # def get_template_name(context):
     #     return f"template-{context['name']}.html"
 
     # This component takes one parameter, a date string to show in the template

--- a/sampleproject/components/calendar/calendar.py
+++ b/sampleproject/components/calendar/calendar.py
@@ -3,10 +3,14 @@ from django_components import Component, register
 
 @register("calendar")
 class Calendar(Component):
-    # Note that Django will look for templates inside `[your apps]/components` dir and
-    # `[project root]/components` dir. To customize which template to use based on context
-    # you can override def get_template_name() instead of specifying the below variable.
+    # Templates inside `[your apps]/components` dir and `[project root]/components` dir
+    # will be automatically found.
+    #
+    # `template_name` can be relative to dir where `calendar.py` is, or relative to STATICFILES_DIRS
     template_name = "calendar/calendar.html"
+    # Or
+    # def template_name(context):
+    #     return f"template-{context['name']}.html"
 
     # This component takes one parameter, a date string to show in the template
     def get_context_data(self, date):
@@ -27,10 +31,14 @@ class Calendar(Component):
 
 @register("calendar_relative")
 class CalendarRelative(Component):
-    # Note that Django will look for templates inside `[your apps]/components` dir and
-    # `[project root]/components` dir. To customize which template to use based on context
-    # you can override def get_template_name() instead of specifying the below variable.
+    # Templates inside `[your apps]/components` dir and `[project root]/components` dir
+    # will be automatically found.
+    #
+    # `template_name` can be relative to dir where `calendar.py` is, or relative to STATICFILES_DIRS
     template_name = "calendar.html"
+    # Or
+    # def template_name(context):
+    #     return f"template-{context['name']}.html"
 
     # This component takes one parameter, a date string to show in the template
     def get_context_data(self, date):

--- a/sampleproject/components/nested/calendar/calendar.py
+++ b/sampleproject/components/nested/calendar/calendar.py
@@ -9,7 +9,7 @@ class CalendarNested(Component):
     # `template_name` can be relative to dir where `calendar.py` is, or relative to STATICFILES_DIRS
     template_name = "calendar.html"
     # Or
-    # def template_name(context):
+    # def get_template_name(context):
     #     return f"template-{context['name']}.html"
 
     # This component takes one parameter, a date string to show in the template

--- a/sampleproject/components/nested/calendar/calendar.py
+++ b/sampleproject/components/nested/calendar/calendar.py
@@ -3,10 +3,14 @@ from django_components import Component, register
 
 @register("calendar_nested")
 class CalendarNested(Component):
-    # Note that Django will look for templates inside `[your apps]/components` dir and
-    # `[project root]/components` dir. To customize which template to use based on context
-    # you can override def get_template_name() instead of specifying the below variable.
+    # Templates inside `[your apps]/components` dir and `[project root]/components` dir
+    # will be automatically found.
+    #
+    # `template_name` can be relative to dir where `calendar.py` is, or relative to STATICFILES_DIRS
     template_name = "calendar.html"
+    # Or
+    # def template_name(context):
+    #     return f"template-{context['name']}.html"
 
     # This component takes one parameter, a date string to show in the template
     def get_context_data(self, date):

--- a/sampleproject/components/todo/todo.py
+++ b/sampleproject/components/todo/todo.py
@@ -2,8 +2,7 @@ from django_components import Component, register
 
 
 @register("todo")
-class Calendar(Component):
-    # Note that Django will look for templates inside `[your apps]/components` dir and
-    # `[project root]/components` dir. To customize which template to use based on context
-    # you can override def get_template_name() instead of specifying the below variable.
+class Todo(Component):
+    # Templates inside `[your apps]/components` dir and `[project root]/components` dir
+    # will be automatically found.
     template_name = "todo/todo.html"

--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -36,6 +36,7 @@ from django_components.tag_formatter import (
     component_formatter as component_formatter,
     component_shorthand_formatter as component_shorthand_formatter,
 )
+from django_components.template import cached_template as cached_template
 import django_components.types as types
 from django_components.types import (
     EmptyTuple as EmptyTuple,

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -293,13 +293,13 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
         template_name = getattr(self, "get_template_name", self.template_name)
         template_str = getattr(self, "get_template_string", self.template)
 
-        if template_name and template_str:
+        if template_name is not None and template_str is not None:
             raise ImproperlyConfigured(
                 f"Received both 'template_name' and 'template' for Component {type(self).__name__}."
                 " Only one of must be set."
             )
 
-        if template_name:
+        if template_name is not None:
             if callable(template_name):
                 template_name = template_name(context)
             else:
@@ -307,7 +307,7 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
 
             return get_template(template_name).template
 
-        elif template_str:
+        elif template_str is not None:
             if callable(template_str):
                 template = template_str(context)
             else:
@@ -631,7 +631,6 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
                 self.on_render_before(context, template)
 
                 rendered_component = template.render(context)
-
                 new_output = self.on_render_after(context, template, rendered_component)
                 rendered_component = new_output if new_output is not None else rendered_component
 

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -63,6 +63,7 @@ from django_components.slots import (
     resolve_fill_nodes,
     resolve_slots,
 )
+from django_components.template import cached_template
 from django_components.utils import gen_id, validate_typed_dict, validate_typed_tuple
 
 # TODO_REMOVE_IN_V1 - Users should use top-level import instead
@@ -314,7 +315,7 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
             
             # We got template string, so we convert it to Template
             if isinstance(template, str):
-                template = Template(template)
+                template = cached_template(template)
 
             return template
 

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -291,7 +291,7 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
     def _get_template(self, context: Context) -> Template:
         # TODO_REMOVE_IN_V1 - Instead use `self.template_name` and `self.template` in v1
         template_name = getattr(self, "get_template_name", self.template_name)
-        template_str =getattr(self, "get_template_string", self.template)
+        template_str = getattr(self, "get_template_string", self.template)
 
         if template_name and template_str:
             raise ImproperlyConfigured(
@@ -312,7 +312,7 @@ class Component(Generic[ArgsType, KwargsType, DataType, SlotsType], metaclass=Co
                 template = template_str(context)
             else:
                 template = template_str
-            
+
             # We got template string, so we convert it to Template
             if isinstance(template, str):
                 template = cached_template(template)

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -725,7 +725,6 @@ def _escape_slot_name(name: str) -> str:
 
 
 def _nodelist_to_slot_render_func(nodelist: NodeList) -> SlotFunc:
-    print("NODELOST: ", nodelist) # TODO
     def render_func(ctx: Context, kwargs: Dict[str, Any], slot_ref: SlotRef) -> SlotResult:
         return nodelist.render(ctx)
 

--- a/src/django_components/template.py
+++ b/src/django_components/template.py
@@ -1,0 +1,43 @@
+from functools import lru_cache
+from typing import Any, Optional, Type, TypeVar
+
+from django.template import Origin, Template
+from django.template.base import UNKNOWN_SOURCE
+
+from django_components.app_settings import app_settings
+from django_components.utils import lazy_cache
+
+
+TTemplate = TypeVar("TTemplate", bound=Template)
+
+
+# Lazily initialize the cache. The cached function takes only the parts that can
+# affect how the template string is processed - Template class, template string, and engine
+@lazy_cache(lambda: lru_cache(maxsize=app_settings.TEMPLATE_CACHE_SIZE))
+def _create_template(
+    template_cls: Type[TTemplate],
+    template_string: str,
+    engine: Optional[Any] = None,
+) -> TTemplate:
+    return template_cls(template_string, engine=engine)
+
+
+# Central logic for creating Templates from string, so we can cache the results
+def cached_template(
+    template_string: str,
+    template_cls: Optional[Type[Template]] = None,
+    origin: Optional[Origin] = None,
+    name: Optional[str] = None,
+    engine: Optional[Any] = None,
+) -> Template:
+    """Create a Template instance that will be cached as per the `TEMPLATE_CACHE_SIZE` setting."""
+    template = _create_template(template_cls or Template, template_string, engine)
+
+    # Assign the origin and name separately, so the caching doesn't depend on them
+    # Since we might be accessing a template from cache, we want to define these only once
+    if not getattr(template, "_dc_cached", False):
+        template.origin = origin or Origin(UNKNOWN_SOURCE)
+        template.name = name
+        template._dc_cached = True
+
+    return template

--- a/src/django_components/template.py
+++ b/src/django_components/template.py
@@ -7,7 +7,6 @@ from django.template.base import UNKNOWN_SOURCE
 from django_components.app_settings import app_settings
 from django_components.utils import lazy_cache
 
-
 TTemplate = TypeVar("TTemplate", bound=Template)
 
 

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -246,7 +246,7 @@ def component(parser: Parser, token: Token, registry: ComponentRegistry, tag_nam
     trace_msg("PARSE", "COMP", result.component_name, tag.id)
 
     body = tag.parse_body()
-    fill_nodes = parse_slot_fill_nodes_from_component_nodelist(body, ignored_nodes=(ComponentNode,))
+    fill_nodes = parse_slot_fill_nodes_from_component_nodelist(tuple(body), ignored_nodes=(ComponentNode,))
 
     # Tag all fill nodes as children of this particular component instance
     for node in fill_nodes:

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -246,7 +246,7 @@ def component(parser: Parser, token: Token, registry: ComponentRegistry, tag_nam
     trace_msg("PARSE", "COMP", result.component_name, tag.id)
 
     body = tag.parse_body()
-    fill_nodes = parse_slot_fill_nodes_from_component_nodelist(body, ComponentNode)
+    fill_nodes = parse_slot_fill_nodes_from_component_nodelist(body, ignored_nodes=(ComponentNode,))
 
     # Tag all fill nodes as children of this particular component instance
     for node in fill_nodes:

--- a/src/django_components/utils.py
+++ b/src/django_components/utils.py
@@ -196,6 +196,17 @@ def lazy_cache(
 
             return _cached_fn(*args, **kwargs)
 
+        # Allow to access the LRU cache methods
+        # See https://stackoverflow.com/a/37654201/9788634
+        wrapper.cache_info = lambda: _cached_fn.cache_info()  # type: ignore
+        wrapper.cache_clear = lambda: _cached_fn.cache_clear()  # type: ignore
+
+        # And allow to remove the cache instance (mostly for tests)
+        def cache_remove() -> None:
+            nonlocal _cached_fn
+            _cached_fn = None
+        wrapper.cache_remove = cache_remove  # type: ignore
+
         return cast(TFunc, wrapper)
 
     return decorator

--- a/src/django_components/utils.py
+++ b/src/django_components/utils.py
@@ -1,7 +1,8 @@
+import functools
 import sys
 import typing
 from pathlib import Path
-from typing import Any, Callable, List, Mapping, Sequence, Tuple, Union, get_type_hints
+from typing import Any, Callable, List, Mapping, Sequence, Tuple, TypeVar, Union, cast, get_type_hints
 
 from django.utils.autoreload import autoreload_started
 
@@ -166,3 +167,32 @@ def validate_typed_dict(value: Mapping[str, Any], dict_type: Any, prefix: str, k
         # `Component 'name' got unexpected slot keys 'invalid_key'`
         # `Component 'name' got unexpected data keys 'invalid_key'`
         raise TypeError(f"{prefix} got unexpected {kind} keys {formatted_keys}")
+
+
+TFunc = TypeVar("TFunc", bound=Callable)
+
+def lazy_cache(
+    make_cache: Callable[[], Callable[[Callable], Callable]],
+) -> Callable[[TFunc], TFunc]:
+    """
+    Decorator that caches the given function similarly to `functools.lru_cache`.
+    But the cache is instantiated only at first invocation.
+    
+    `cache` argument is a function that generates the cache function,
+    e.g. `functools.lru_cache()`.
+    """
+    _cached_fn = None
+
+    def decorator(fn: TFunc) -> TFunc:
+        @functools.wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            # Lazily initialize the cache
+            nonlocal _cached_fn
+            if not _cached_fn:
+                # E.g. `lambda: functools.lru_cache(maxsize=app_settings.TEMPLATE_CACHE_SIZE)`
+                cache = make_cache()
+                _cached_fn = cache(fn)
+
+            return _cached_fn(*args, **kwargs)
+        return cast(TFunc, wrapper)
+    return decorator

--- a/src/django_components/utils.py
+++ b/src/django_components/utils.py
@@ -171,13 +171,14 @@ def validate_typed_dict(value: Mapping[str, Any], dict_type: Any, prefix: str, k
 
 TFunc = TypeVar("TFunc", bound=Callable)
 
+
 def lazy_cache(
     make_cache: Callable[[], Callable[[Callable], Callable]],
 ) -> Callable[[TFunc], TFunc]:
     """
     Decorator that caches the given function similarly to `functools.lru_cache`.
     But the cache is instantiated only at first invocation.
-    
+
     `cache` argument is a function that generates the cache function,
     e.g. `functools.lru_cache()`.
     """
@@ -194,5 +195,7 @@ def lazy_cache(
                 _cached_fn = cache(fn)
 
             return _cached_fn(*args, **kwargs)
+
         return cast(TFunc, wrapper)
+
     return decorator

--- a/src/django_components/utils.py
+++ b/src/django_components/utils.py
@@ -205,6 +205,7 @@ def lazy_cache(
         def cache_remove() -> None:
             nonlocal _cached_fn
             _cached_fn = None
+
         wrapper.cache_remove = cache_remove  # type: ignore
 
         return cast(TFunc, wrapper)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1093,7 +1093,6 @@ class ComponentRenderTest(BaseTestCase):
 
 
 class ComponentHookTest(BaseTestCase):
-    @parametrize_context_behavior(["django", "isolated"])
     def test_on_render_before(self):
         class SimpleComponent(Component):
             template: types.django_html = """
@@ -1131,7 +1130,6 @@ class ComponentHookTest(BaseTestCase):
         )
 
     # Check that modifying the context or template does nothing
-    @parametrize_context_behavior(["django", "isolated"])
     def test_on_render_after(self):
         captured_content = None
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -208,7 +208,7 @@ class ComponentTest(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
     def test_template_string_dynamic(self):
         class SimpleComponent(Component):
-            def template(self, context):
+            def get_template(self, context):
                 content: types.django_html = """
                     Variable: <strong>{{ variable }}</strong>
                 """
@@ -264,7 +264,7 @@ class ComponentTest(BaseTestCase):
                     **attrs,
                 }
 
-            def template_name(self, context):
+            def get_template_name(self, context):
                 return f"dynamic_{context['name']}.svg"
 
         self.assertHTMLEqual(
@@ -288,7 +288,7 @@ class ComponentTest(BaseTestCase):
                     "variable": variable,
                 }
 
-            def template(self, context):
+            def get_template(self, context):
                 template_str = "Variable: <strong>{{ variable }}</strong>"
                 return Template(template_str)
 
@@ -316,7 +316,7 @@ class ComponentTest(BaseTestCase):
                 }
 
             @no_type_check
-            def template(self, context):
+            def get_template(self, context):
                 tester.assertEqual(self.input.args, (123, "str"))
                 tester.assertEqual(self.input.kwargs, {"variable": "test", "another": 1})
                 tester.assertIsInstance(self.input.context, Context)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -76,7 +76,7 @@ else:
         optional: NotRequired[int]
 
 
-# TODO_REMOVE_IN_V1 - Instead use `self.template_name` and `self.template` in v1
+# TODO_REMOVE_IN_V1 - Superseded by `self.get_template` in v1
 class ComponentOldTemplateApiTest(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
     def test_get_template_string(self):
@@ -101,33 +101,6 @@ class ComponentOldTemplateApiTest(BaseTestCase):
             rendered,
             """
             Variable: <strong>test</strong>
-            """,
-        )
-
-    @parametrize_context_behavior(["django", "isolated"])
-    def test_get_template_name(self):
-        class SvgComponent(Component):
-            def get_context_data(self, name, css_class="", title="", **attrs):
-                return {
-                    "name": name,
-                    "css_class": css_class,
-                    "title": title,
-                    **attrs,
-                }
-
-            def get_template_name(self, context):
-                return f"dynamic_{context['name']}.svg"
-
-        self.assertHTMLEqual(
-            SvgComponent.render(kwargs={"name": "svg1"}),
-            """
-            <svg>Dynamic1</svg>
-            """,
-        )
-        self.assertHTMLEqual(
-            SvgComponent.render(kwargs={"name": "svg2"}),
-            """
-            <svg>Dynamic2</svg>
             """,
         )
 

--- a/tests/test_component_media.py
+++ b/tests/test_component_media.py
@@ -122,7 +122,7 @@ class InlineComponentTest(BaseTestCase):
 
     def test_html_variable(self):
         class VariableHTMLComponent(Component):
-            def get_template(self, context):
+            def template(self, context):
                 return Template("<div class='variable-html'>{{ variable }}</div>")
 
         comp = VariableHTMLComponent("variable_html_component")

--- a/tests/test_component_media.py
+++ b/tests/test_component_media.py
@@ -122,7 +122,7 @@ class InlineComponentTest(BaseTestCase):
 
     def test_html_variable(self):
         class VariableHTMLComponent(Component):
-            def template(self, context):
+            def get_template(self, context):
                 return Template("<div class='variable-html'>{{ variable }}</div>")
 
         comp = VariableHTMLComponent("variable_html_component")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -48,7 +48,7 @@ class TemplateCacheTest(BaseTestCase):
 
     def test_component_template_is_cached(self):
         class SimpleComponent(Component):
-            def template(self, context):
+            def get_template(self, context):
                 content: types.django_html = """
                     Variable: <strong>{{ variable }}</strong>
                 """

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,67 @@
+from django.template import Context, Template
+from django.test import override_settings
+
+from django_components import Component, cached_template, types
+
+from .django_test_setup import setup_test_config
+from .testutils import BaseTestCase
+
+setup_test_config({"autodiscover": False})
+
+
+class TemplateCacheTest(BaseTestCase):
+    def test_cached_template(self):
+        template_1 = cached_template("Variable: <strong>{{ variable }}</strong>")
+        template_1._test_id = "123"
+
+        template_2 = cached_template("Variable: <strong>{{ variable }}</strong>")
+
+        self.assertEqual(template_2._test_id, "123")
+
+    def test_cached_template_accepts_class(self):
+        class MyTemplate(Template):
+            pass
+
+        template = cached_template("Variable: <strong>{{ variable }}</strong>", MyTemplate)
+        self.assertIsInstance(template, MyTemplate)
+
+    @override_settings(COMPONENTS={"template_cache_size": 2})
+    def test_cache_discards_old_entries(self):
+        template_1 = cached_template("Variable: <strong>{{ variable }}</strong>")
+        template_1._test_id = "123"
+
+        template_2 = cached_template("Variable2")
+        template_2._test_id = "456"
+
+        # Templates 1 and 2 should still be available
+        template_1_copy = cached_template("Variable: <strong>{{ variable }}</strong>")
+        self.assertEqual(template_1_copy._test_id, "123")
+
+        template_2_copy = cached_template("Variable2")
+        self.assertEqual(template_2_copy._test_id, "456")
+
+        # But once we add the third template, template 1 should go
+        cached_template("Variable3")
+
+        template_1_copy2 = cached_template("Variable: <strong>{{ variable }}</strong>")
+        self.assertEqual(hasattr(template_1_copy2, "_test_id"), False)
+
+    def test_component_template_is_cached(self):
+        class SimpleComponent(Component):
+            def template(self, context):
+                content: types.django_html = """
+                    Variable: <strong>{{ variable }}</strong>
+                """
+                return content
+
+            def get_context_data(self, variable=None):
+                return {
+                    "variable": variable,
+                }
+
+        comp = SimpleComponent()
+        template_1 = comp._get_template(Context({}))
+        template_1._test_id = "123"
+
+        template_2 = comp._get_template(Context({}))
+        self.assertEqual(template_2._test_id, "123")

--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -434,7 +434,7 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
     def test_component_template_cannot_have_multiple_default_slots(self):
         class BadComponent(Component):
-            def template(self, context):
+            def get_template(self, context):
                 template_str: types.django_html = """
                     {% load django_components %}
                     <div>

--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -434,7 +434,7 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
     def test_component_template_cannot_have_multiple_default_slots(self):
         class BadComponent(Component):
-            def get_template(self, context, template_name: Optional[str] = None) -> Template:
+            def template(self, context):
                 template_str: types.django_html = """
                     {% load django_components %}
                     <div>

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -24,6 +24,9 @@ class BaseTestCase(SimpleTestCase):
         super().tearDown()
         registry.clear()
 
+        from django_components.template import _create_template
+        _create_template.cache_remove()  # type: ignore[attr-defined]
+
 
 request = Mock()
 mock_template = Mock()

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -25,6 +25,7 @@ class BaseTestCase(SimpleTestCase):
         registry.clear()
 
         from django_components.template import _create_template
+
         _create_template.cache_remove()  # type: ignore[attr-defined]
 
 


### PR DESCRIPTION
Changes:
- Reintroduce template caching using the `TEMPLATE_CACHE_SIZE` setting (fixes https://github.com/EmilStenstrom/django-components/issues/589)

- Also caches the process of extracting `{% fill %}` tags from `{% component %}` tags

- Add a way for users to manually add Templates to the cache using `cached_template`

Also relevant API cleanup / changes:
- The undocumented `Component.get_template` is made private as `_get_template`

- Introduced new `get_template`, which works like `get_template_string`, except it can return either a string or a Template instance. And I tagged `get_template_string` to be deprecated and will work till v1.

- Also updated the logic so that all 4 ways of defining the template are mutually exclusive, as previously it was ambiguous which one of e.g. `template_name` vs `get_template_name` should take priority.

Closes https://github.com/EmilStenstrom/django-components/issues/589

Note: Initially I tried to merge `template_name` and `get_template_name` into a single attribute, and same with `template` and `get_template`, to reduce the number of variables. And it mostly worked, but Mypy had issues with that. So I reverted back to all 4 ways.
