### PR TITLE
chore: fix docs build on tag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,8 +79,13 @@ jobs:
           hatch run docs:mike deploy --push --update-aliases --title "dev (${SHORT_SHA})" dev
 
       - name: Build & deploy docs for a new tag
-        if: github.ref_type == 'tag' && github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref_type == 'tag'
         run: |
+          # git checkout -b temp-docs   # Give current position meaningful name
+          # git checkout gh-pages       # Update `gh-pages` to avoid conflicts
+          # git pull origin gh-pages
+          # git checkout temp-docs      # Go back to where we started
+
           # XXX next line removes docs wrongly deployed under latest identifier; remove once latest is used only as alias
           hatch run docs:mike delete --push latest
           hatch run docs:mike deploy --push --update-aliases ${{ github.ref_name }} latest
@@ -89,6 +94,11 @@ jobs:
       - name: Build & deploy docs for a new release
         if: github.event_name == 'release'
         run: |
+          # git checkout -b temp-docs   # Give current position meaningful name
+          # git checkout gh-pages       # Update `gh-pages` to avoid conflicts
+          # git pull origin gh-pages
+          # git checkout temp-docs      # Go back to where we started
+
           # XXX next line removes docs wrongly deployed under latest identifier; remove once latest is used only as alias
           hatch run docs:mike delete --push latest
           hatch run docs:mike deploy --push --update-aliases ${{ github.ref_name }} latest


### PR DESCRIPTION
There was still a issue with docs building, though the issue is now with git conflicts on pushing tags.

See https://github.com/EmilStenstrom/django-components/actions/runs/10708912382/job/29692325879

```
error: failed to push branch gh-pages to origin:
  To https://github.com/EmilStenstrom/django-components
   ! [remote rejected] gh-pages -> gh-pages (cannot lock ref 'refs/heads/gh-pages': is at 973e7f9eb1a14391202bf90279c2e0e322369ca8 but expected c29784977a30befd7411119c8c3170bf098fd5c9)
  error: failed to push some refs to 'https://github.com/EmilStenstrom/django-components'
```

On my fork I was able to resolve the issue with the code included.

IMPORTANT: When making a release or pushing a tag, you MUST WAIT before other pipelines are done! So when you do combo 1. push to master, 2. push a tag, wait 1-2 minutes between then.