### PR TITLE
Minimize tox config and add black

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,63 +4,52 @@
 
 [tox]
 envlist =
-  py38-django{42}
-  py39-django{42}
-  py310-django{42,50}
-  py311-django{42,50}
-  py312-django{42,50}
+  py{38,39}-django42
+  py{310,311,312}-django{42,50}
   flake8
   isort
   coverage
   mypy
+  black
 
 [gh-actions]
 python =
-  3.8: py38-django{42}
-  3.9: py39-django{42}
+  3.8: py38-django42
+  3.9: py39-django42
   3.10: py310-django{42,50}
   3.11: py311-django{42,50}
-  3.12: py312-django{42,50}, flake8, isort, coverage, mypy
-fail_on_no_env = True
+  3.12: py312-django{42,50}, flake8, isort, coverage, mypy, black
 
 isolated_build = true
 
 [testenv]
 package = wheel
-wheel_build_env = .pkg
 deps =
   django42: Django>=4.2,<4.3
   django50: Django>=5.0,<5.1
   pytest
   pytest-xdist
-  flake8
-  isort
-allowlist_externals = py.test
-commands = py.test {posargs}
+commands = pytest {posargs}
 
 [testenv:flake8]
-changedir = {toxinidir}
-deps =
-  flake8
-  flake8-pyproject
-commands =
-  flake8 .
+deps = flake8
+       flake8-pyproject
+commands = flake8 .
 
 [testenv:isort]
-changedir = {toxinidir}
 deps = isort
-commands =
-  isort --check-only --diff src/django_components
+commands = isort --check-only --diff src/django_components
 
 [testenv:coverage]
-changedir = {toxinidir}
 deps = pytest-coverage
 commands =
   coverage run --branch -m pytest
   coverage report -m --fail-under=97
 
 [testenv:mypy]
-changedir = {toxinidir}
 deps = mypy
-commands =
-  mypy .
+commands = mypy .
+
+[testenv:black]
+deps = black
+commands = black --check src/django_components

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ isolated_build = true
 
 [testenv]
 package = wheel
+wheel_build_env = .pkg
 deps =
   django42: Django>=4.2,<4.3
   django50: Django>=5.0,<5.1


### PR DESCRIPTION
I've gone through and made sure we're not including lots of unessesary cruft in the tox.ini, and also added black so that it doesn't just exist in the pre-commit config.

Experimented with adding bandit check but decided against it because it just added lots of false positives.