### PR TITLE
Make sure BASE_DIR is a Path - fixesd #687

### DIFF
--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -1,5 +1,6 @@
 import re
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 from django.conf import settings
@@ -101,7 +102,8 @@ class AppSettings:
 
     @property
     def DIRS(self) -> List[Union[str, Tuple[str, str]]]:
-        return self.settings.get("dirs", [settings.BASE_DIR / "components"])
+        base_dir_path = Path(settings.BASE_DIR)
+        return self.settings.get("dirs", [base_dir_path / "components"])
 
     @property
     def APP_DIRS(self) -> List[str]:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from django.test import override_settings
 
 from django_components.app_settings import app_settings

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from django.test import override_settings
 
 from django_components.app_settings import app_settings
@@ -17,3 +18,11 @@ class SettingsTestCase(BaseTestCase):
     def test_raises_on_invalid_context_behavior(self):
         with self.assertRaises(ValueError):
             app_settings.CONTEXT_BEHAVIOR
+
+    @override_settings(BASE_DIR="base_dir")
+    def test_works_when_base_dir_is_string(self):
+        self.assertEqual(app_settings.DIRS, [Path("base_dir/components")])
+
+    @override_settings(BASE_DIR=Path("base_dir"))
+    def test_works_when_base_dir_is_path(self):
+        self.assertEqual(app_settings.DIRS, [Path("base_dir/components")])


### PR DESCRIPTION
This coverts BASE_DIR to a `pathlib.Path`. It works fine if BASE_DIR is already a Path.