### PR TITLE
refactor: selectolax update and tests cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     'Django>=4.2',
-    'selectolax>=0.3',
+    'selectolax>=0.3.24',
 ]
 license = {text = "MIT"}
 

--- a/src/django_components/dependencies.py
+++ b/src/django_components/dependencies.py
@@ -368,13 +368,13 @@ def render_dependencies(content: TContent, type: RenderType = "document") -> TCo
             did_modify_html = False
 
             if not did_find_css_placeholder and tree.head:
-                _, css_elems = parse_multiroot_html(css_dependencies.decode())
+                css_elems = parse_multiroot_html(css_dependencies.decode())
                 for css_elem in css_elems:
                     tree.head.insert_child(css_elem)  # type: ignore # TODO: Update to selectolax 0.3.25
                 did_modify_html = True
 
             if not did_find_js_placeholder and tree.body:
-                _, js_elems = parse_multiroot_html(js_dependencies.decode())
+                js_elems = parse_multiroot_html(js_dependencies.decode())
                 for js_elem in js_elems:
                     tree.body.insert_child(js_elem)  # type: ignore # TODO: Update to selectolax 0.3.25
                 did_modify_html = True

--- a/src/django_components/dependencies.py
+++ b/src/django_components/dependencies.py
@@ -32,10 +32,10 @@ from django.templatetags.static import static
 from django.urls import path, reverse
 from django.utils.decorators import sync_and_async_middleware
 from django.utils.safestring import SafeString, mark_safe
-from selectolax.lexbor import LexborNode
+from selectolax.lexbor import LexborHTMLParser
 
 import django_components.types as types
-from django_components.html import insert_before_end, parse_node, transform_html_document
+from django_components.html import parse_multiroot_html, parse_node
 from django_components.utils import escape_js_string_literal, get_import_path
 
 if TYPE_CHECKING:
@@ -362,20 +362,22 @@ def render_dependencies(content: TContent, type: RenderType = "document") -> TCo
     # then try to insert the JS scripts at the end of <body> and CSS sheets at the end
     # of <head>
     if type == "document" and (not did_find_js_placeholder or not did_find_css_placeholder):
+        tree = LexborHTMLParser(content_.decode())
         did_modify_html = False
 
-        def do_transform(head: Optional[LexborNode], body: Optional[LexborNode]) -> None:
-            nonlocal did_modify_html
+        if not did_find_css_placeholder and tree.head:
+            _, css_elems = parse_multiroot_html(css_dependencies.decode())
+            for css_elem in css_elems:
+                tree.head.insert_child(css_elem)
+            did_modify_html = True
 
-            if not did_find_css_placeholder and head:
-                insert_before_end(head, css_dependencies.decode())
-                did_modify_html = True
-            if not did_find_js_placeholder and body:
-                insert_before_end(body, js_dependencies.decode())
-                did_modify_html = True
+        if not did_find_js_placeholder and tree.body:
+            _, js_elems = parse_multiroot_html(js_dependencies.decode())
+            for js_elem in js_elems:
+                tree.body.insert_child(js_elem)
+            did_modify_html = True
 
-        transformed = transform_html_document(content_.decode(), do_transform)
-
+        transformed = cast(str, tree.html)
         if did_modify_html:
             content_ = transformed.encode()
 

--- a/src/django_components/html.py
+++ b/src/django_components/html.py
@@ -1,5 +1,4 @@
-import re
-from typing import Dict, Optional, Protocol, Union, cast
+from typing import List, Tuple, cast
 
 from selectolax.lexbor import LexborHTMLParser, LexborNode
 
@@ -11,91 +10,12 @@ def parse_node(html: str) -> LexborNode:
     return parser.body.child or parser.head.child  # type: ignore[union-attr, return-value]
 
 
-# NOTE: While Selectolax offers way to insert a node before or after
-# a current one, it doesn't allow to insert one node into another.
-# See https://github.com/rushter/selectolax/issues/126
-def html_insert_before_end(html: str, insert_html: str) -> str:
-    regex = re.compile(r"<\/\w+>$")
-    return regex.sub(
-        lambda m: insert_html + m[0],
-        html.strip(),
-    )
+def parse_multiroot_html(html: str) -> Tuple[LexborNode, List[LexborNode]]:
+    # NOTE: HTML / XML MUST have a single root. So, to support multiple
+    # top-level elements, we wrap them in a dummy singular root.
+    parser = LexborHTMLParser(f"<root>{html}</root>")
 
-
-def insert_before_end(node: LexborNode, insert: Union[LexborNode, str]) -> None:
-    the_insert = insert.html or "" if isinstance(insert, LexborNode) else insert
-    new_node_html = html_insert_before_end(node.html or "", the_insert)
-    new_node = parse_node(new_node_html)
-    node.replace_with(new_node)  # type: ignore[arg-type]
-    node.insert_before(new_node)  # type: ignore[arg-type]
-
-
-HTML_ROOT_TAGS_REGEX = re.compile(
-    r"<!doctype|<html|</html|<head|</head|<body|</body",
-    re.IGNORECASE,
-)
-
-HTML_ROOT_TAGS_REVERSE_REGEX = re.compile(
-    r"<doctype_|<html_|</html_|<head_|</head_|<body_|</body_",
-    re.IGNORECASE,
-)
-
-
-html_tag_escapes: Dict[str, str] = {
-    "<!doctype": "<doctype_",
-    "<html": "<html_",
-    "</html": "</html_",
-    "<head": "<head_",
-    "</head": "</head_",
-    "<body": "<body_",
-    "</body": "</body_",
-}
-html_tag_escapes_reverse = {val: key for key, val in html_tag_escapes.items()}
-
-
-class TransformHtmlCallback(Protocol):
-    def __call__(self, head: Optional[LexborNode], body: Optional[LexborNode]) -> None: ...  # noqa: #704
-
-
-# TODO: Remove `transform_html_document`, `insert_before_end`, `html_insert_before_end`
-#       Once Selectolax supports `LaxborNode.insert_child()`
-#       See https://github.com/rushter/selectolax/issues/128
-def transform_html_document(html: str, transform: TransformHtmlCallback) -> str:
-    # Escape <!doctype>, <html>, <head>, and <body> tags, because Selectolax treats them
-    # specially, which makes it impossible to edit them.
-    def on_replace_match(match: "re.Match[str]") -> str:
-        match_str = match[0].lower()
-        return html_tag_escapes[match_str]
-
-    escaped_html = HTML_ROOT_TAGS_REGEX.sub(on_replace_match, html)
-
-    # Selectolax now treats the escaped tags as custom tags, and so Selectolax wraps
-    # the whole content in extra <html><head></head><body> CONTENT </body></html>.
-    # So the actual HTML is under `.body.child`
-    wrapper_tree = LexborHTMLParser(escaped_html).body
-    escaped_tree = wrapper_tree.child if wrapper_tree else None
-    if escaped_tree:
-        body_matches = escaped_tree.css("body_")
-        head_matches = escaped_tree.css("head_")
-        body = body_matches[0] if body_matches else None
-        head = head_matches[0] if head_matches else None
-    else:
-        body = None
-        head = None
-
-    # Finally, we can pass the actual <head> and <body> tags to be transformed
-    # The transformations happen in-place in Selectolax.
-    transform(head, body)
-    transformed_html = cast(str, escaped_tree.html) if escaped_tree else ""
-
-    # After the transformations are applied, we need to un-escape the <doctype_>, <head_>, etc tags
-    def on_reverse_replace_match(match: "re.Match[str]") -> str:
-        match_str = match[0].lower()
-        return html_tag_escapes_reverse[match_str]
-
-    final_html = HTML_ROOT_TAGS_REVERSE_REGEX.sub(on_reverse_replace_match, transformed_html)
-
-    # NOTE: Because of how we work around selectolax to enable modifying the <body> and <head>
-    # tags, selectolax also adds `</doctype_>` at the end of the content when we serialize the HTML.
-    # So we have to remove that.
-    return final_html[: -len("</doctype_>")]
+    # Get all contents of the root
+    root_elem = parser.css_first("root")
+    elems = [*root_elem.iter()] if root_elem else []
+    return cast(LexborNode, root_elem), elems

--- a/src/django_components/html.py
+++ b/src/django_components/html.py
@@ -1,16 +1,42 @@
-from typing import List, Tuple, cast
+from typing import List, Tuple, Union, cast
 
 from selectolax.lexbor import LexborHTMLParser, LexborNode
 
 
 def parse_node(html: str) -> LexborNode:
-    parser = LexborHTMLParser(html)
+    """
+    Use this when you know the given HTML is a single node like
+
+    `<div> Hi </div>`
+    """
+    tree = LexborHTMLParser(html)
     # NOTE: The parser automatically places <style> tags inside <head>
     # while <script> tags are inside <body>.
-    return parser.body.child or parser.head.child  # type: ignore[union-attr, return-value]
+    return tree.body.child or tree.head.child  # type: ignore[union-attr, return-value]
+
+
+def parse_document_or_nodes(html: str) -> Union[List[LexborNode], LexborHTMLParser]:
+    """
+    Use this if you do NOT know whether the given HTML is a full document
+    with `<html>`, `<head>`, and `<body>` tags, or an HTML fragment.
+    """
+    html = html.strip()
+    tree = LexborHTMLParser(html)
+    is_fragment = is_html_parser_fragment(html, tree)
+
+    if is_fragment:
+        _, nodes = parse_multiroot_html(html)
+        return nodes
+    else:
+        return tree
 
 
 def parse_multiroot_html(html: str) -> Tuple[LexborNode, List[LexborNode]]:
+    """
+    Use this when you know the given HTML is a multiple nodes like
+
+    `<div> Hi </div> <span> Hello </span>`
+    """
     # NOTE: HTML / XML MUST have a single root. So, to support multiple
     # top-level elements, we wrap them in a dummy singular root.
     parser = LexborHTMLParser(f"<root>{html}</root>")
@@ -19,3 +45,56 @@ def parse_multiroot_html(html: str) -> Tuple[LexborNode, List[LexborNode]]:
     root_elem = parser.css_first("root")
     elems = [*root_elem.iter()] if root_elem else []
     return cast(LexborNode, root_elem), elems
+
+
+def is_html_parser_fragment(html: str, tree: LexborHTMLParser) -> bool:
+    # If we pass only an HTML fragment to the parser, like `<div>123</div>`, then
+    # the parser automatically wraps it in `<html>`, `<head>`, and `<body>` tags.
+    #
+    # <html>
+    #   <head>
+    #   </head>
+    #   <body>
+    #     <div>123</div>
+    #   </body>
+    # </html>
+    #
+    # But also, as described in Lexbor (https://github.com/lexbor/lexbor/issues/183#issuecomment-1611975340),
+    # if the parser first comes across HTML tags that could go into the `<head>`,
+    # it will put them there, and then put the rest in `<body>`.
+    #
+    # So `<link href="..." /><div></div>` will be parsed as
+    #
+    # <html>
+    #   <head>
+    #     <link href="..." />
+    #   </head>
+    #   <body>
+    #     <div>123</div>
+    #   </body>
+    # </html>
+    #
+    # BUT, if we're dealing with a fragment, we want to parse it correctly as
+    # a multi-root fragment:
+    #
+    # <link href="..." />
+    # <div>123</div>
+    #
+    # The way do so is that we:
+    # 1. Take the original HTML string
+    # 2. Subtract the content of parsed `<head>` from the START of the original HTML
+    # 3. Subtract the content of parsed `<body>` from the END of the original HTML
+    # 4. Then, if we have an HTML fragment, we should be left with empty string (maybe whitespace?).
+    # 5. But if we have an HTML document, then the "space between" should contain text,
+    #    because we didn't account for the length of `<html>`, `<head>`, `<body>` tags.
+    #
+    # TODO: Replace with fragment parser?
+    #       See https://github.com/rushter/selectolax/issues/74#issuecomment-2404470344
+    parsed_head_html: str = tree.head.html  # type: ignore
+    parsed_body_html: str = tree.head.html  # type: ignore
+    head_content = parsed_head_html[len("<head>") : -len("</head>")]  # noqa: E203
+    body_content = parsed_body_html[len("<body>") : -len("<body>")]  # noqa: E203
+    between_content = html[len(head_content) : -len(body_content)].strip()  # noqa: E203
+
+    is_fragment = not html or not between_content
+    return is_fragment

--- a/src/django_components/html.py
+++ b/src/django_components/html.py
@@ -91,9 +91,9 @@ def is_html_parser_fragment(html: str, tree: LexborHTMLParser) -> bool:
     # TODO: Replace with fragment parser?
     #       See https://github.com/rushter/selectolax/issues/74#issuecomment-2404470344
     parsed_head_html: str = tree.head.html  # type: ignore
-    parsed_body_html: str = tree.head.html  # type: ignore
+    parsed_body_html: str = tree.body.html  # type: ignore
     head_content = parsed_head_html[len("<head>") : -len("</head>")]  # noqa: E203
-    body_content = parsed_body_html[len("<body>") : -len("<body>")]  # noqa: E203
+    body_content = parsed_body_html[len("<body>") : -len("</body>")]  # noqa: E203
     between_content = html[len(head_content) : -len(body_content)].strip()  # noqa: E203
 
     is_fragment = not html or not between_content

--- a/src/django_components/html.py
+++ b/src/django_components/html.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union, cast
+from typing import List, Union
 
 from selectolax.lexbor import LexborHTMLParser, LexborNode
 
@@ -25,13 +25,13 @@ def parse_document_or_nodes(html: str) -> Union[List[LexborNode], LexborHTMLPars
     is_fragment = is_html_parser_fragment(html, tree)
 
     if is_fragment:
-        _, nodes = parse_multiroot_html(html)
+        nodes = parse_multiroot_html(html)
         return nodes
     else:
         return tree
 
 
-def parse_multiroot_html(html: str) -> Tuple[LexborNode, List[LexborNode]]:
+def parse_multiroot_html(html: str) -> List[LexborNode]:
     """
     Use this when you know the given HTML is a multiple nodes like
 
@@ -44,7 +44,7 @@ def parse_multiroot_html(html: str) -> Tuple[LexborNode, List[LexborNode]]:
     # Get all contents of the root
     root_elem = parser.css_first("root")
     elems = [*root_elem.iter()] if root_elem else []
-    return cast(LexborNode, root_elem), elems
+    return elems
 
 
 def is_html_parser_fragment(html: str, tree: LexborHTMLParser) -> bool:

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Callable, Dict, List, Literal, NamedTuple, Optional, Set, Union
+from typing import Callable, Dict, List, Literal, NamedTuple, Optional, Set, Union
 
 import django.template
 from django.template.base import NodeList, Parser, Token, TokenType
@@ -9,7 +9,6 @@ from django.utils.text import smart_split
 from django_components.attributes import HTML_ATTRS_ATTRS_KEY, HTML_ATTRS_DEFAULTS_KEY, HtmlAttrsNode
 from django_components.component import COMP_ONLY_FLAG, ComponentNode
 from django_components.component_registry import ComponentRegistry
-from django_components.component_registry import registry as component_registry
 from django_components.dependencies import CSS_DEPENDENCY_PLACEHOLDER, JS_DEPENDENCY_PLACEHOLDER
 from django_components.expression import (
     DynamicFilterExpression,
@@ -42,27 +41,10 @@ from django_components.tag_formatter import get_tag_formatter
 from django_components.template_parser import parse_bits
 from django_components.utils import gen_id
 
-if TYPE_CHECKING:
-    from django_components.component import Component
-
 
 # NOTE: Variable name `register` is required by Django to recognize this as a template tag library
 # See https://docs.djangoproject.com/en/dev/howto/custom-template-tags
 register = django.template.Library()
-
-
-def _get_components_from_preload_str(preload_str: str) -> List["Component"]:
-    """Returns a list of unique components from a comma-separated str"""
-
-    components = []
-    for component_name in preload_str.split(","):
-        component_name = component_name.strip()
-        if not component_name:
-            continue
-        component_class = component_registry.get(component_name)
-        components.append(component_class(component_name))
-
-    return components
 
 
 def _component_dependencies(kind: Literal["js", "css", "both"]) -> SafeString:

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -41,7 +41,6 @@ from django_components.tag_formatter import get_tag_formatter
 from django_components.template_parser import parse_bits
 from django_components.utils import gen_id
 
-
 # NOTE: Variable name `register` is required by Django to recognize this as a template tag library
 # See https://docs.djangoproject.com/en/dev/howto/custom-template-tags
 register = django.template.Library()

--- a/tests/test_dependency_rendering.py
+++ b/tests/test_dependency_rendering.py
@@ -4,7 +4,6 @@ During actual rendering, the HTML is then picked up by the JS-side dependency ma
 """
 
 import re
-from unittest import skip
 
 from django.template import Template
 
@@ -165,38 +164,6 @@ class DependencyRenderingTests(BaseTestCase):
         self.assertEqual(rendered.count("<link"), 0)  # No CSS
         self.assertEqual(rendered.count("<style"), 0)
 
-    @skip("Old implementation of preload no longer compatible - needs rework")
-    def test_preload_dependencies_render_when_no_components_used(self):
-        registry.register(name="test", component=SimpleComponent)
-
-        template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies preload='test' %}
-        """
-        template = Template(template_str)
-        rendered = create_and_process_template_response(template)
-
-        self.assertInHTML('<script src="script.js">', rendered, count=1)
-        self.assertInHTML(
-            '<link href="style.css" media="all" rel="stylesheet"/>',
-            rendered,
-            count=1,
-        )
-
-    @skip("Old implementation of preload no longer compatible - needs rework")
-    def test_preload_css_dependencies_render_when_no_components_used(self):
-        registry.register(name="test", component=SimpleComponent)
-
-        template_str: types.django_html = """
-            {% load component_tags %}{% component_css_dependencies preload='test' %}
-        """
-        template = Template(template_str)
-        rendered = create_and_process_template_response(template)
-        self.assertInHTML(
-            '<link href="style.css" media="all" rel="stylesheet"/>',
-            rendered,
-            count=1,
-        )
-
     def test_single_component_dependencies(self):
         registry.register(name="test", component=SimpleComponent)
 
@@ -263,23 +230,6 @@ class DependencyRenderingTests(BaseTestCase):
             1,
         )
 
-    @skip("Old implementation of preload no longer compatible - needs rework")
-    def test_preload_dependencies_render_once_when_used(self):
-        registry.register(name="test", component=SimpleComponent)
-
-        template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies preload='test' %}
-            {% component 'test' variable='foo' / %}
-        """
-        template = Template(template_str)
-        rendered = create_and_process_template_response(template)
-        self.assertInHTML(
-            '<link href="style.css" media="all" rel="stylesheet"/>',
-            rendered,
-            count=1,
-        )
-        self.assertInHTML('<script src="script.js">', rendered, count=1)
-
     def test_single_component_placeholder_removed(self):
         registry.register(name="test", component=SimpleComponent)
 
@@ -290,17 +240,6 @@ class DependencyRenderingTests(BaseTestCase):
         template = Template(template_str)
         rendered = create_and_process_template_response(template)
 
-        self.assertNotIn("_RENDERED", rendered)
-
-    @skip("Old implementation of preload no longer compatible - needs rework")
-    def test_placeholder_removed_when_preload_rendered(self):
-        registry.register(name="test", component=SimpleComponent)
-
-        template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies preload='test' %}
-        """
-        template = Template(template_str)
-        rendered = create_and_process_template_response(template)
         self.assertNotIn("_RENDERED", rendered)
 
     def test_single_component_css_dependencies(self):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -51,16 +51,8 @@ class HtmlTests(TestCase):
                 Hello
             </span>
         """
-        root, nodes = parse_multiroot_html(html)
+        nodes = parse_multiroot_html(html)
 
-        self.assertHTMLEqual(
-            root.html,
-            f"""
-            <root>
-                {html}
-            </root>
-            """,
-        )
         self.assertHTMLEqual(
             nodes[0].html,
             """

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,6 +1,9 @@
-from django.test import TestCase
+from typing import List, cast
 
-from django_components.html import parse_multiroot_html, parse_node
+from django.test import TestCase
+from selectolax.lexbor import LexborHTMLParser, LexborNode
+
+from django_components.html import is_html_parser_fragment, parse_document_or_nodes, parse_multiroot_html, parse_node
 
 from .django_test_setup import setup_test_config
 
@@ -84,5 +87,184 @@ class HtmlTests(TestCase):
             <span>
                 Hello
             </span>
+            """,
+        )
+
+    def test_is_html_parser_fragment(self):
+        fragment_html = """
+            <div class="abc xyz" data-id="123">
+                <ul>
+                    <li>Hi</li>
+                </ul>
+            </div>
+            <main id="123" class="one">
+                <div>
+                    42
+                </div>
+            </main>
+            <span>
+                Hello
+            </span>
+        """
+        fragment_tree = LexborHTMLParser(fragment_html)
+        fragment_result = is_html_parser_fragment(fragment_html, fragment_tree)
+
+        self.assertEqual(fragment_result, True)
+
+        doc_html = """
+            <!doctype html>
+            <html>
+              <head>
+                <link href="https://..." />
+              </head>
+              <body>
+                <div class="abc xyz" data-id="123">
+                    <ul>
+                        <li>Hi</li>
+                    </ul>
+                </div>
+              </body>
+            </html>
+        """
+        doc_tree = LexborHTMLParser(doc_html)
+        doc_result = is_html_parser_fragment(doc_html, doc_tree)
+
+        self.assertEqual(doc_result, False)
+
+    def test_parse_document_or_nodes__fragment(self):
+        fragment_html = """
+            <div class="abc xyz" data-id="123">
+                <ul>
+                    <li>Hi</li>
+                </ul>
+            </div>
+            <main id="123" class="one">
+                <div>
+                    42
+                </div>
+            </main>
+            <span>
+                Hello
+            </span>
+        """
+        fragment_result = cast(List[LexborNode], parse_document_or_nodes(fragment_html))
+
+        self.assertHTMLEqual(
+            fragment_result[0].html,
+            """
+            <div class="abc xyz" data-id="123">
+                <ul>
+                    <li>Hi</li>
+                </ul>
+            </div>
+            """,
+        )
+        self.assertHTMLEqual(
+            fragment_result[1].html,
+            """
+            <main id="123" class="one">
+                <div>
+                    42
+                </div>
+            </main>
+            """,
+        )
+        self.assertHTMLEqual(
+            fragment_result[2].html,
+            """
+            <span>
+                Hello
+            </span>
+            """,
+        )
+
+    def test_parse_document_or_nodes__mixed(self):
+        fragment_html = """
+            <link href="" />
+            <div class="abc xyz" data-id="123">
+                <ul>
+                    <li>Hi</li>
+                </ul>
+            </div>
+            <main id="123" class="one">
+                <div>
+                    42
+                </div>
+            </main>
+            <span>
+                Hello
+            </span>
+        """
+        fragment_result = cast(List[LexborNode], parse_document_or_nodes(fragment_html))
+
+        self.assertHTMLEqual(
+            fragment_result[0].html,
+            """
+            <link href="" />
+            """,
+        )
+        self.assertHTMLEqual(
+            fragment_result[1].html,
+            """
+            <div class="abc xyz" data-id="123">
+                <ul>
+                    <li>Hi</li>
+                </ul>
+            </div>
+            """,
+        )
+        self.assertHTMLEqual(
+            fragment_result[2].html,
+            """
+            <main id="123" class="one">
+                <div>
+                    42
+                </div>
+            </main>
+            """,
+        )
+        self.assertHTMLEqual(
+            fragment_result[3].html,
+            """
+            <span>
+                Hello
+            </span>
+            """,
+        )
+
+    def test_parse_document_or_nodes__doc(self):
+        doc_html = """
+            <!doctype html>
+            <html>
+              <head>
+                <link href="https://..." />
+              </head>
+              <body>
+                <div class="abc xyz" data-id="123">
+                    <ul>
+                        <li>Hi</li>
+                    </ul>
+                </div>
+              </body>
+            </html>
+        """
+        fragment_result = cast(LexborHTMLParser, parse_document_or_nodes(doc_html))
+
+        self.assertHTMLEqual(
+            fragment_result.html,
+            """
+            <!doctype html>
+            <html>
+              <head>
+                <link href="https://..." />
+              </head>
+              <body>
+                <div class="abc xyz" data-id="123">
+                    <ul>
+                        <li>Hi</li>
+                    </ul>
+                </div>
+              </body>
+            </html>
             """,
         )


### PR DESCRIPTION
Some of a cleanup as mentioned here https://github.com/EmilStenstrom/django-components/pull/688#issuecomment-2400732761

Changes:
- Add test for noJS browser (https://github.com/EmilStenstrom/django-components/commit/3ac74d22a77994fa5c75ccf193cdcc7387355d39)
- Remove skipped tests that tested preloading (https://github.com/EmilStenstrom/django-components/commit/2d2ec48b9c2c6b154c277c756691be805ea23f7b)
- Remove leftover code for preloading (https://github.com/EmilStenstrom/django-components/commit/696f027b5298b3e320e20250bb4f57041ab198c8)
- Update selectolax to use Node.insert_child (https://github.com/EmilStenstrom/django-components/commit/20612e2d0e5a2e01bd330a1b148216a377f5295f)