### PR TITLE
refactor: remove joint {% component_dependencies %} tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
         a [flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content),
         as either JS scripts will block the rendering, or CSS will load too late.
 
-- The undocumented keyword arg `preload` of `{% component_js_dependencies %}` and `{% component_csss_dependencies %}` tags was removed.
+- The undocumented keyword arg `preload` of `{% component_js_dependencies %}` and `{% component_css_dependencies %}` tags was removed.
   This will be replaced with HTML fragment support.
 
 - Component typing signature changed from

--- a/README.md
+++ b/README.md
@@ -3031,7 +3031,6 @@ Then, by default, the components' JS and CSS will be automatically inserted into
 
 If you want to place the dependencies elsewhere, you can override that with following Django template tags:
 
-- `{% component_dependencies %}` - Renders both JS and CSS
 - `{% component_js_dependencies %}` - Renders only JS
 - `{% component_css_dependencies %}` - Renders only CSS
 
@@ -3065,10 +3064,10 @@ class MyButton(Component):
 ```
 
 Then the inlined JS and the scripts in `Media.js` will be rendered at the default place,
-or in `{% component_dependencies %}` and `{% component_js_dependencies %}`.
+or in `{% component_js_dependencies %}`.
 
 And the inlined CSS and the styles in `Media.css` will be rendered at the default place,
-or in `{% component_dependencies %}` and `{% component_css_dependencies %}`.
+or in `{% component_css_dependencies %}`.
 
 And if you don't specify `{% component_dependencies %}` tags, it is the equivalent of:
 

--- a/benchmarks/component_rendering.py
+++ b/benchmarks/component_rendering.py
@@ -120,7 +120,9 @@ class RenderBenchmarks(BaseTestCase):
 
     def test_middleware_time_with_dependency_for_small_page(self):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
             {% component 'test_component' %}
                 {% slot "header" %}
                     {% component 'inner_component' variable='foo' %}{% endcomponent %}

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -653,7 +653,7 @@ class Component(
                 template,
                 component_name=self.name,
                 fill_content=fill_content,
-                # Dynamic component has a special mark do it doesn't raise certain errors
+                # Dynamic component has a special mark so it doesn't raise certain errors
                 is_dynamic_component=getattr(self, "_is_dynamic_component", False),
             )
 

--- a/src/django_components/dependencies.py
+++ b/src/django_components/dependencies.py
@@ -295,9 +295,8 @@ def render_dependencies(content: TContent, type: RenderType = "document") -> TCo
     - CSS is inserted at the end of `<head>` (if present)
     - JS is inserted at the end of `<body>` (if present)
 
-    If you used `{% component_dependencies %}`, `{% component_js_dependencies %}`
-    or `{% component_css_dependencies %}`, then the JS and CSS will be inserted
-    only at these locations.
+    If you used `{% component_js_dependencies %}` or `{% component_css_dependencies %}`,
+    then the JS and CSS will be inserted only at these locations.
 
     Example:
     ```python
@@ -358,7 +357,7 @@ def render_dependencies(content: TContent, type: RenderType = "document") -> TCo
 
     content_ = PLACEHOLDER_REGEX.sub(on_replace_match, content_)
 
-    # By default, if user didn't specify any `{% component_dependencies %}` (or the JS/CSS variants),
+    # By default, if user didn't specify any `{% component_dependencies %}`,
     # then try to insert the JS scripts at the end of <body> and CSS sheets at the end
     # of <head>
     if type == "document" and (not did_find_js_placeholder or not did_find_css_placeholder):

--- a/src/django_components/library.py
+++ b/src/django_components/library.py
@@ -16,7 +16,6 @@ class TagProtectedError(Exception):
 
 
 PROTECTED_TAGS = [
-    "component_dependencies",
     "component_css_dependencies",
     "component_js_dependencies",
     "fill",

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -54,8 +54,7 @@ def _component_dependencies(kind: Literal["js", "css"]) -> SafeString:
         placeholder = JS_DEPENDENCY_PLACEHOLDER
     else:
         raise TemplateSyntaxError(
-            "Unknown dependency type in {% component_dependencies %}. Must be one of 'css' or 'js', "
-            f"got {type}"
+            "Unknown dependency type in {% component_dependencies %}. Must be one of 'css' or 'js', " f"got {type}"
         )
 
     return mark_safe(placeholder)

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -46,22 +46,19 @@ from django_components.utils import gen_id
 register = django.template.Library()
 
 
-def _component_dependencies(kind: Literal["js", "css", "both"]) -> SafeString:
+def _component_dependencies(kind: Literal["js", "css"]) -> SafeString:
     """Marks location where CSS link and JS script tags should be rendered."""
-    content = ""
+    if kind == "css":
+        placeholder = CSS_DEPENDENCY_PLACEHOLDER
+    elif kind == "js":
+        placeholder = JS_DEPENDENCY_PLACEHOLDER
+    else:
+        raise TemplateSyntaxError(
+            "Unknown dependency type in {% component_dependencies %}. Must be one of 'css' or 'js', "
+            f"got {type}"
+        )
 
-    if kind in ("css", "both"):
-        content += CSS_DEPENDENCY_PLACEHOLDER
-    if kind in ("js", "both"):
-        content += JS_DEPENDENCY_PLACEHOLDER
-
-    return mark_safe(content)
-
-
-@register.simple_tag(name="component_dependencies")
-def component_dependencies() -> SafeString:
-    """Marks location where CSS link and JS script tags should be rendered."""
-    return _component_dependencies("both")
+    return mark_safe(placeholder)
 
 
 @register.simple_tag(name="component_css_dependencies")

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -46,15 +46,15 @@ from django_components.utils import gen_id
 register = django.template.Library()
 
 
-def _component_dependencies(kind: Literal["js", "css"]) -> SafeString:
+def _component_dependencies(type: Literal["js", "css"]) -> SafeString:
     """Marks location where CSS link and JS script tags should be rendered."""
-    if kind == "css":
+    if type == "css":
         placeholder = CSS_DEPENDENCY_PLACEHOLDER
-    elif kind == "js":
+    elif type == "js":
         placeholder = JS_DEPENDENCY_PLACEHOLDER
     else:
         raise TemplateSyntaxError(
-            "Unknown dependency type in {% component_dependencies %}. Must be one of 'css' or 'js', " f"got {type}"
+            f"Unknown dependency type in {{% component_dependencies %}}. Must be one of 'css' or 'js', got {type}"
         )
 
     return mark_safe(placeholder)

--- a/tests/components/relative_file_pathobj/relative_file_pathobj.html
+++ b/tests/components/relative_file_pathobj/relative_file_pathobj.html
@@ -1,5 +1,6 @@
 {% load component_tags %}
-{% component_dependencies %}
+{% component_js_dependencies %}
+{% component_css_dependencies %}
 <form method="post">
   {% csrf_token %}
   <input type="text" name="variable" value="{{ variable }}">

--- a/tests/test_component_media.py
+++ b/tests/test_component_media.py
@@ -31,7 +31,8 @@ class InlineComponentTest(BaseTestCase):
         class TestComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
                 <div class='html-css-only'>Content</div>
             """
             css = ".html-css-only { color: blue; }"
@@ -92,7 +93,8 @@ class ComponentMediaTests(BaseTestCase):
         class SimpleComponent(Component):
             template: types.django_html = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
                 Variable: <strong>{{ variable }}</strong>
             """
 
@@ -110,7 +112,8 @@ class ComponentMediaTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             class Media:
@@ -132,7 +135,8 @@ class ComponentMediaTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             class Media:
@@ -153,7 +157,8 @@ class ComponentMediaTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             class Media:
@@ -188,7 +193,8 @@ class ComponentMediaTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             media_class = MyMedia
@@ -221,7 +227,8 @@ class ComponentMediaTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             media_class = MyMedia
@@ -278,7 +285,8 @@ class MediaPathAsObjectTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             class Media:
@@ -340,7 +348,8 @@ class MediaPathAsObjectTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             class Media:
@@ -393,7 +402,8 @@ class MediaPathAsObjectTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             class Media:
@@ -441,7 +451,8 @@ class MediaPathAsObjectTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             class Media:
@@ -481,7 +492,8 @@ class MediaPathAsObjectTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             class Media:
@@ -530,7 +542,8 @@ class MediaPathAsObjectTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             class Media:
@@ -605,7 +618,8 @@ class MediaStaticfilesTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             media_class = MyMedia
@@ -666,7 +680,8 @@ class MediaStaticfilesTests(BaseTestCase):
         class SimpleComponent(Component):
             template = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
             """
 
             media_class = MyMedia
@@ -756,7 +771,8 @@ class MediaRelativePathTests(BaseTestCase):
 
             template_str: types.django_html = """
                 {% load component_tags %}
-                {% component_dependencies %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
                 {% component name='relative_file_component' variable=variable / %}
             """
             template = Template(template_str)
@@ -797,7 +813,9 @@ class MediaRelativePathTests(BaseTestCase):
             registry.unregister("relative_file_pathobj_component")
 
             template_str: types.django_html = """
-                {% load component_tags %}{% component_dependencies %}
+                {% load component_tags %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
                 {% component 'parent_component' %}
                     {% fill 'content' %}
                         {% component name='relative_file_component' variable='hello' %}

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -94,7 +94,7 @@ class ContextTests(BaseTestCase):
         self,
     ):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'parent_component' %}{% endcomponent %}
         """
         template = Template(template_str)
@@ -114,7 +114,6 @@ class ContextTests(BaseTestCase):
     ):
         template_str: types.django_html = """
             {% load component_tags %}
-            {% component_dependencies %}
             {% component name='parent_component' %}{% endcomponent %}
         """
         template = Template(template_str)
@@ -130,7 +129,7 @@ class ContextTests(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
     def test_nested_component_context_shadows_parent_with_filled_slots(self):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'parent_component' %}
                 {% fill 'content' %}
                     {% component name='variable_display' shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}
@@ -153,7 +152,6 @@ class ContextTests(BaseTestCase):
     def test_nested_component_instances_have_unique_context_with_filled_slots(self):
         template_str: types.django_html = """
             {% load component_tags %}
-            {% component_dependencies %}
             {% component 'parent_component' %}
                 {% fill 'content' %}
                     {% component name='variable_display' shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}
@@ -177,7 +175,6 @@ class ContextTests(BaseTestCase):
     ):
         template_str: types.django_html = """
             {% load component_tags %}
-            {% component_dependencies %}
             {% component name='parent_component' %}{% endcomponent %}
         """
         template = Template(template_str)
@@ -196,7 +193,7 @@ class ContextTests(BaseTestCase):
         self,
     ):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'parent_component' %}
                 {% fill 'content' %}
                     {% component name='variable_display' shadowing_variable='shadow_from_slot' new_variable='unique_from_slot' %}
@@ -272,7 +269,7 @@ class ParentArgsTests(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
     def test_parent_args_available_outside_slots(self):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'parent_with_args' parent_value='passed_in' %}{%endcomponent %}
         """
         template = Template(template_str)
@@ -444,7 +441,7 @@ class IsolatedContextTests(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
     def test_simple_component_can_pass_outer_context_in_args(self):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'simple_component' variable only %}{% endcomponent %}
         """
         template = Template(template_str)
@@ -454,7 +451,7 @@ class IsolatedContextTests(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
     def test_simple_component_cannot_use_outer_context(self):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'simple_component' only %}{% endcomponent %}
         """
         template = Template(template_str)
@@ -472,7 +469,7 @@ class IsolatedContextSettingTests(BaseTestCase):
         self,
     ):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'simple_component' variable %}{% endcomponent %}
         """
         template = Template(template_str)
@@ -484,7 +481,7 @@ class IsolatedContextSettingTests(BaseTestCase):
         self,
     ):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'simple_component' %}{% endcomponent %}
         """
         template = Template(template_str)
@@ -496,7 +493,7 @@ class IsolatedContextSettingTests(BaseTestCase):
         self,
     ):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'simple_component' variable %}
             {% endcomponent %}
         """
@@ -509,7 +506,7 @@ class IsolatedContextSettingTests(BaseTestCase):
         self,
     ):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'simple_component' %}
             {% endcomponent %}
         """
@@ -534,7 +531,7 @@ class OuterContextPropertyTests(BaseTestCase):
     @parametrize_context_behavior(["django", "isolated"])
     def test_outer_context_property_with_component(self):
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
             {% component 'outer_context_component' only %}{% endcomponent %}
         """
         template = Template(template_str)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -100,11 +100,14 @@ class RenderDependenciesTests(BaseTestCase):
 
     def test_component_render_renders_dependencies(self):
         class SimpleComponentWithDeps(SimpleComponent):
-            template: types.django_html = """
+            template: types.django_html = (
+                """
                 {% load component_tags %}
                 {% component_js_dependencies %}
                 {% component_css_dependencies %}
-            """ + SimpleComponent.template
+            """
+                + SimpleComponent.template
+            )
 
         registry.register(name="test", component=SimpleComponentWithDeps)
 
@@ -126,11 +129,14 @@ class RenderDependenciesTests(BaseTestCase):
 
     def test_component_render_renders_dependencies_opt_out(self):
         class SimpleComponentWithDeps(SimpleComponent):
-            template: types.django_html = """
+            template: types.django_html = (
+                """
                 {% load component_tags %}
                 {% component_js_dependencies %}
                 {% component_css_dependencies %}
-            """ + SimpleComponent.template
+            """
+                + SimpleComponent.template
+            )
 
         registry.register(name="test", component=SimpleComponentWithDeps)
 
@@ -158,11 +164,14 @@ class RenderDependenciesTests(BaseTestCase):
 
     def test_component_render_to_response_renders_dependencies(self):
         class SimpleComponentWithDeps(SimpleComponent):
-            template: types.django_html = """
+            template: types.django_html = (
+                """
                 {% load component_tags %}
                 {% component_js_dependencies %}
                 {% component_css_dependencies %}
-            """ + SimpleComponent.template
+            """
+                + SimpleComponent.template
+            )
 
         registry.register(name="test", component=SimpleComponentWithDeps)
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -131,10 +131,10 @@ class RenderDependenciesTests(BaseTestCase):
         class SimpleComponentWithDeps(SimpleComponent):
             template: types.django_html = (
                 """
-                {% load component_tags %}
-                {% component_js_dependencies %}
-                {% component_css_dependencies %}
-            """
+                    {% load component_tags %}
+                    {% component_js_dependencies %}
+                    {% component_css_dependencies %}
+                """
                 + SimpleComponent.template
             )
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -166,10 +166,10 @@ class RenderDependenciesTests(BaseTestCase):
         class SimpleComponentWithDeps(SimpleComponent):
             template: types.django_html = (
                 """
-                {% load component_tags %}
-                {% component_js_dependencies %}
-                {% component_css_dependencies %}
-            """
+                    {% load component_tags %}
+                    {% component_js_dependencies %}
+                    {% component_css_dependencies %}
+                """
                 + SimpleComponent.template
             )
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -45,7 +45,9 @@ class RenderDependenciesTests(BaseTestCase):
         registry.register(name="test", component=SimpleComponent)
 
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
             {% component 'test' variable='foo' / %}
         """
         template = Template(template_str)
@@ -76,7 +78,9 @@ class RenderDependenciesTests(BaseTestCase):
         registry.register(name="test", component=SimpleComponent)
 
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
             {% component 'test' variable='foo' / %}
         """
         template = Template(template_str)
@@ -96,7 +100,11 @@ class RenderDependenciesTests(BaseTestCase):
 
     def test_component_render_renders_dependencies(self):
         class SimpleComponentWithDeps(SimpleComponent):
-            template = "{% load component_tags %}{% component_dependencies %}" + SimpleComponent.template
+            template: types.django_html = """
+                {% load component_tags %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
+            """ + SimpleComponent.template
 
         registry.register(name="test", component=SimpleComponentWithDeps)
 
@@ -118,7 +126,11 @@ class RenderDependenciesTests(BaseTestCase):
 
     def test_component_render_renders_dependencies_opt_out(self):
         class SimpleComponentWithDeps(SimpleComponent):
-            template = "{% load component_tags %}{% component_dependencies %}" + SimpleComponent.template
+            template: types.django_html = """
+                {% load component_tags %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
+            """ + SimpleComponent.template
 
         registry.register(name="test", component=SimpleComponentWithDeps)
 
@@ -146,7 +158,11 @@ class RenderDependenciesTests(BaseTestCase):
 
     def test_component_render_to_response_renders_dependencies(self):
         class SimpleComponentWithDeps(SimpleComponent):
-            template = "{% load component_tags %}{% component_dependencies %}" + SimpleComponent.template
+            template: types.django_html = """
+                {% load component_tags %}
+                {% component_js_dependencies %}
+                {% component_css_dependencies %}
+            """ + SimpleComponent.template
 
         registry.register(name="test", component=SimpleComponentWithDeps)
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -102,10 +102,10 @@ class RenderDependenciesTests(BaseTestCase):
         class SimpleComponentWithDeps(SimpleComponent):
             template: types.django_html = (
                 """
-                {% load component_tags %}
-                {% component_js_dependencies %}
-                {% component_css_dependencies %}
-            """
+                    {% load component_tags %}
+                    {% component_js_dependencies %}
+                    {% component_css_dependencies %}
+                """
                 + SimpleComponent.template
             )
 

--- a/tests/test_dependency_rendering.py
+++ b/tests/test_dependency_rendering.py
@@ -113,7 +113,9 @@ class DependencyRenderingTests(BaseTestCase):
         registry.register(name="test", component=SimpleComponent)
 
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
         """
         template = Template(template_str)
         rendered = create_and_process_template_response(template)
@@ -168,7 +170,9 @@ class DependencyRenderingTests(BaseTestCase):
         registry.register(name="test", component=SimpleComponent)
 
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
             {% component 'test' variable='foo' / %}
         """
         template = Template(template_str)
@@ -201,7 +205,9 @@ class DependencyRenderingTests(BaseTestCase):
         registry.register(name="te-s/t", component=SimpleComponent)
 
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
             {% component 'te-s/t' variable='foo' / %}
         """
         template = Template(template_str)
@@ -234,7 +240,9 @@ class DependencyRenderingTests(BaseTestCase):
         registry.register(name="test", component=SimpleComponent)
 
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
             {% component 'test' variable='foo' / %}
         """
         template = Template(template_str)
@@ -299,7 +307,9 @@ class DependencyRenderingTests(BaseTestCase):
     ):
         registry.register(name="test", component=MultistyleComponent)
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
             {% component 'test' / %}
         """
         template = Template(template_str)
@@ -337,7 +347,9 @@ class DependencyRenderingTests(BaseTestCase):
         registry.register(name="outer", component=SimpleComponentNested)
 
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
         """
         template = Template(template_str)
         rendered = create_and_process_template_response(template)
@@ -360,7 +372,9 @@ class DependencyRenderingTests(BaseTestCase):
         registry.register(name="other", component=OtherComponent)
 
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
             {% component 'outer' variable='variable' %}
                 {% component 'other' variable='variable_inner' / %}
             {% endcomponent %}
@@ -418,7 +432,9 @@ class DependencyRenderingTests(BaseTestCase):
         registry.register(name="test", component=SimpleComponentWithSharedDependency)
 
         template_str: types.django_html = """
-            {% load component_tags %}{% component_dependencies %}
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
             {% component 'inner' variable='variable' / %}
             {% component 'outer' variable='variable' / %}
             {% component 'test' variable='variable' / %}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -228,7 +228,6 @@ class ProtectedTagsTest(unittest.TestCase):
     @override_settings(COMPONENTS={"tag_formatter": "django_components.component_shorthand_formatter"})
     def test_raises_on_overriding_our_tags(self):
         for tag in [
-            "component_dependencies",
             "component_css_dependencies",
             "component_js_dependencies",
             "fill",


### PR DESCRIPTION
More cleanup as originally mentioned here https://github.com/EmilStenstrom/django-components/pull/688#issuecomment-2400732761

This one removes `{% component_dependencies %}`, leaving only the JS- and CSS-specific variants.

See the rationale here https://github.com/EmilStenstrom/django-components/pull/706/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14