### PR TITLE
refactor: pass slot fills in template via slots param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
     )
     ```
 
+#### Fix
+
+- Slots defined with `{% fill %}` tags are now properly accessible via `self.input.slots` in `get_context_data()`
+
 #### Refactor
 
 - `{% component_dependencies %}` tags are now OPTIONAL - If your components use JS and CSS, but you don't use `{% component_dependencies %}` tags, the JS and CSS will now be, by default, inserted at the end of `<body>` and at the end of `<head>` respectively.

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -51,9 +51,9 @@ from django_components.expression import Expression, RuntimeKwargs, safe_resolve
 from django_components.node import BaseNode
 from django_components.slots import (
     DEFAULT_SLOT_KEY,
-    FillContent,
     FillNode,
     SlotContent,
+    SlotFunc,
     SlotName,
     SlotRef,
     SlotResult,
@@ -290,7 +290,6 @@ class Component(
         registered_name: Optional[str] = None,
         component_id: Optional[str] = None,
         outer_context: Optional[Context] = None,
-        fill_content: Optional[Dict[str, FillContent]] = None,
         registry: Optional[ComponentRegistry] = None,  # noqa F811
     ):
         # When user first instantiates the component class before calling
@@ -310,7 +309,6 @@ class Component(
 
         self.registered_name: Optional[str] = registered_name
         self.outer_context: Context = outer_context or Context()
-        self.fill_content = fill_content or {}
         self.component_id = component_id or gen_id()
         self.registry = registry or registry_
         self._render_stack: Deque[RenderStackItem[ArgsType, KwargsType, SlotsType]] = deque()
@@ -632,8 +630,6 @@ class Component(
         type: RenderType = "document",
         render_dependencies: bool = True,
     ) -> str:
-        has_slots = slots is not None
-
         # Allow to provide no args/kwargs/slots/context
         args = cast(ArgsType, args or ())
         kwargs = cast(KwargsType, kwargs or {})
@@ -674,20 +670,13 @@ class Component(
         cache_inlined_css(self.__class__, self.css or "")
 
         with _prepare_template(self, context, context_data) as template:
-            # Support passing slots explicitly to `render` method
-            if has_slots:
-                fill_content = self._fills_from_slots_data(
-                    slots,
-                    escape_slots_content,
-                )
-            else:
-                fill_content = self.fill_content
+            fills = self._escape_slot_fills(slots, escape_slots_content)
 
             _, resolved_fills = resolve_slots(
                 context,
                 template,
                 component_name=self.name,
-                fill_content=fill_content,
+                fills=fills,
                 # Dynamic component has a special mark so it doesn't raise certain errors
                 is_dynamic_component=getattr(self, "_is_dynamic_component", False),
             )
@@ -740,17 +729,20 @@ class Component(
 
         return output
 
-    def _fills_from_slots_data(
+    def _escape_slot_fills(
         self,
-        slots_data: Mapping[SlotName, SlotContent],
+        fills: Mapping[SlotName, SlotContent],
         escape_content: bool = True,
-    ) -> Dict[SlotName, FillContent]:
-        """Fill component slots outside of template rendering."""
-        slot_fills = {}
-        for slot_name, content in slots_data.items():
+    ) -> Dict[SlotName, SlotFunc]:
+        # Preprocess slots to escape content if `escape_content=True`
+        norm_fills = {}
+        for slot_name, content in fills.items():
             if not callable(content):
                 content_func = _nodelist_to_slot_render_func(
-                    NodeList([TextNode(conditional_escape(content) if escape_content else content)])
+                    slot_name,
+                    NodeList([TextNode(conditional_escape(content) if escape_content else content)]),
+                    data_var=None,
+                    default_var=None,
                 )
             else:
 
@@ -762,12 +754,9 @@ class Component(
                     rendered = content(ctx, kwargs, slot_ref)
                     return conditional_escape(rendered) if escape_content else rendered
 
-            slot_fills[slot_name] = FillContent(
-                content_func=content_func,
-                slot_default_var=None,
-                slot_data_var=None,
-            )
-        return slot_fills
+            norm_fills[slot_name] = content_func
+
+        return norm_fills
 
     # #####################################
     # VALIDATION
@@ -903,20 +892,20 @@ class ComponentNode(BaseNode):
 
         is_default_slot = len(self.fill_nodes) == 1 and self.fill_nodes[0].is_implicit
         if is_default_slot:
-            fill_content: Dict[str, FillContent] = {
-                DEFAULT_SLOT_KEY: FillContent(
-                    content_func=_nodelist_to_slot_render_func(self.fill_nodes[0].nodelist),
-                    slot_data_var=None,
-                    slot_default_var=None,
+            slots: Dict[str, SlotFunc] = {
+                DEFAULT_SLOT_KEY: _nodelist_to_slot_render_func(
+                    "<default>",
+                    self.fill_nodes[0].nodelist,
+                    data_var=None,
+                    default_var=None,
                 ),
             }
         else:
-            fill_content = resolve_fill_nodes(context, self.fill_nodes, self.name)
+            slots = resolve_fill_nodes(context, self.fill_nodes, self.name)
 
         component: Component = component_cls(
             registered_name=self.name,
             outer_context=context,
-            fill_content=fill_content,
             component_id=self.node_id,
             registry=self.registry,
         )
@@ -929,6 +918,7 @@ class ComponentNode(BaseNode):
             context=context,
             args=args,
             kwargs=kwargs,
+            slots=slots,
             # NOTE: When we render components inside the template via template tags,
             # do NOT render deps, because this may be decided by outer component
             render_dependencies=False,

--- a/src/django_components/components/dynamic.py
+++ b/src/django_components/components/dynamic.py
@@ -103,13 +103,13 @@ class DynamicComponent(Component):
             registered_name=self.registered_name,
             component_id=self.component_id,
             outer_context=self.outer_context,
-            fill_content=self.fill_content,
             registry=self.registry,
         )
         output = comp.render(
             context=self.input.context,
             args=args,
             kwargs=kwargs,
+            slots=self.input.slots,
             escape_slots_content=self.input.escape_slots_content,
             type=self.input.type,
             render_dependencies=self.input.render_dependencies,

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -697,7 +697,7 @@ def _nodelist_to_slot_render_func(
 
         # If slot fill is using `{% fill "myslot" default="abc" %}`, then set the "abc" to
         # the context, so users can refer to the default slot from within the fill content.
-        if data_var:
+        if default_var:
             ctx[default_var] = slot_ref
 
         return nodelist.render(ctx)

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -67,29 +67,6 @@ SlotContent = Union[SlotResult, SlotFunc[TSlotData]]
 # Internal type aliases
 SlotId = str
 SlotName = str
-SlotDefaultName = str
-SlotDataName = str
-
-
-@dataclass(frozen=True)
-class FillContent(Generic[TSlotData]):
-    """
-    This represents content set with the `{% fill %}` tag, e.g.:
-
-    ```django
-    {% component "my_comp" %}
-        {% fill "first_slot" %} <--- This
-            hi
-            {{ my_var }}
-            hello
-        {% endfill %}
-    {% endcomponent %}
-    ```
-    """
-
-    content_func: SlotFunc[TSlotData]
-    slot_default_var: Optional[SlotDefaultName]
-    slot_data_var: Optional[SlotDataName]
 
 
 class Slot(NamedTuple):
@@ -124,8 +101,6 @@ class SlotFill(Generic[TSlotData]):
     escaped_name: str
     is_filled: bool
     content_func: SlotFunc[TSlotData]
-    slot_default_var: Optional[SlotDefaultName]
-    slot_data_var: Optional[SlotDataName]
 
 
 class SlotRef:
@@ -195,27 +170,7 @@ class SlotNode(BaseNode):
             if key.startswith(_INJECT_CONTEXT_KEY_PREFIX):
                 extra_context[key] = value
 
-        # If slot fill is using `{% fill "myslot" default="abc" %}`, then set the "abc" to
-        # the context, so users can refer to the default slot from within the fill content.
         slot_ref = SlotRef(self, context)
-        default_var = slot_fill.slot_default_var
-        if default_var:
-            if not default_var.isidentifier():
-                raise TemplateSyntaxError(
-                    f"Slot default alias in fill '{name}' must be a valid identifier. Got '{default_var}'"
-                )
-            extra_context[default_var] = slot_ref
-
-        # Expose the kwargs that were passed to the `{% slot %}` tag. These kwargs
-        # are made available through a variable name that was set on the `{% fill %}`
-        # tag.
-        data_var = slot_fill.slot_data_var
-        if data_var:
-            if not data_var.isidentifier():
-                raise TemplateSyntaxError(
-                    f"Slot data alias in fill '{name}' must be a valid identifier. Got '{data_var}'"
-                )
-            extra_context[data_var] = kwargs
 
         # For the user-provided slot fill, we want to use the context of where the slot
         # came from (or current context if configured so)
@@ -441,8 +396,8 @@ def resolve_fill_nodes(
     context: Context,
     fill_nodes: List[FillNode],
     component_name: str,
-) -> Dict[str, FillContent]:
-    fill_content: Dict[str, FillContent] = {}
+) -> Dict[str, SlotFunc]:
+    fill_content: Dict[str, SlotFunc] = {}
     for fill_node in fill_nodes:
         # Note that outer component context is used to resolve variables in
         # fill tag.
@@ -461,10 +416,11 @@ def resolve_fill_nodes(
                 f"Detected duplicate fill tag name '{fill_name}'."
             )
 
-        fill_content[fill_name] = FillContent(
-            content_func=_nodelist_to_slot_render_func(fill_node.nodelist),
-            slot_default_var=fill_kwargs[SLOT_DEFAULT_KWARG],
-            slot_data_var=fill_kwargs[SLOT_DATA_KWARG],
+        fill_content[fill_name] = _nodelist_to_slot_render_func(
+            fill_name,
+            fill_node.nodelist,
+            data_var=fill_kwargs[SLOT_DATA_KWARG],
+            default_var=fill_kwargs[SLOT_DEFAULT_KWARG],
         )
     return fill_content
 
@@ -478,7 +434,7 @@ def resolve_slots(
     context: Context,
     template: Template,
     component_name: Optional[str],
-    fill_content: Dict[SlotName, FillContent],
+    fills: Dict[SlotName, SlotFunc],
     is_dynamic_component: bool = False,
 ) -> Tuple[Dict[SlotId, Slot], Dict[SlotId, SlotFill]]:
     """
@@ -494,11 +450,9 @@ def resolve_slots(
             name=name,
             escaped_name=_escape_slot_name(name),
             is_filled=True,
-            content_func=fill.content_func,
-            slot_default_var=fill.slot_default_var,
-            slot_data_var=fill.slot_data_var,
+            content_func=slot_fn,
         )
-        for name, fill in fill_content.items()
+        for name, slot_fn in fills.items()
     }
 
     slots: Dict[SlotId, Slot] = {}
@@ -587,9 +541,7 @@ def resolve_slots(
                 name=slot.name,
                 escaped_name=_escape_slot_name(slot.name),
                 is_filled=False,
-                content_func=_nodelist_to_slot_render_func(slot.nodelist),
-                slot_default_var=None,
-                slot_data_var=None,
+                content_func=_nodelist_to_slot_render_func(slot.name, slot.nodelist, None, None),
             )
             # Since the slot's default CAN include other slots (because it's defined in
             # the same template), we need to enqueue the slot's children
@@ -638,8 +590,6 @@ def _resolve_default_slot(
             named_fills[slot.name] = SlotFill(
                 is_filled=default_fill.is_filled,
                 content_func=default_fill.content_func,
-                slot_default_var=default_fill.slot_default_var,
-                slot_data_var=default_fill.slot_data_var,
                 # Updated fields
                 name=slot.name,
                 escaped_name=_escape_slot_name(slot.name),
@@ -720,8 +670,36 @@ def _escape_slot_name(name: str) -> str:
     return escaped_name
 
 
-def _nodelist_to_slot_render_func(nodelist: NodeList) -> SlotFunc:
+def _nodelist_to_slot_render_func(
+    slot_name: str,
+    nodelist: NodeList,
+    data_var: Optional[str] = None,
+    default_var: Optional[str] = None,
+) -> SlotFunc:
+    if data_var:
+        if not data_var.isidentifier():
+            raise TemplateSyntaxError(
+                f"Slot data alias in fill '{slot_name}' must be a valid identifier. Got '{data_var}'"
+            )
+
+    if default_var:
+        if not default_var.isidentifier():
+            raise TemplateSyntaxError(
+                f"Slot default alias in fill '{slot_name}' must be a valid identifier. Got '{default_var}'"
+            )
+
     def render_func(ctx: Context, slot_data: Dict[str, Any], slot_ref: SlotRef) -> SlotResult:
+        # Expose the kwargs that were passed to the `{% slot %}` tag. These kwargs
+        # are made available through a variable name that was set on the `{% fill %}`
+        # tag.
+        if data_var:
+            ctx[data_var] = slot_data
+
+        # If slot fill is using `{% fill "myslot" default="abc" %}`, then set the "abc" to
+        # the context, so users can refer to the default slot from within the fill content.
+        if data_var:
+            ctx[default_var] = slot_ref
+
         return nodelist.render(ctx)
 
     return render_func  # type: ignore[return-value]


### PR DESCRIPTION
## Side note

As I was updating the docs, I've found 4 bugs, plus did some tweaks. I want to first fix the bugs / push the tweaks, before I finish the docs, so that I won't have to re-visit the docs afterwards.

So when it comes to PRs, my course of actions is to:

1. Fix the bugs
2. Submit the tweaks
3. And only then I will be again making PRs documenting the API with docstrings (like the [last one](https://github.com/EmilStenstrom/django-components/pull/716))
4. After that, it will be possible to make PRs in parallel for both documentation (breaking up and migrating the README)
   and the rest of the[ features like JS/CSS vars](https://docs.google.com/document/d/1A9GfJrYHpmbcXUkQfk0wJFmjJyJs5vlfFESWHPb1w-k/edit?usp=sharing), etc.

Bugs:
- `self.input.slots` is empty when component is given slots inside the template via `{% fill %}` tags
- Using multiple `{% slot "slot_name" default %}` tags raises error even if those slots use the same name.
- Type validation doesn't handle nested dictionaries
- `reload_on_template_change` doesn't actually work. And the logic is watching only templates.


Tweaks:
- Rename `forbidden_static_files` to `static_files_forbidden` so it aligns with `static_files_allowed`
- Add `js_name` and `css_name` attributes, which are the JS / CSS equivalents of `template_name`.
  - Same as with `template_name`, `js/css_name` and `js/css` are mutually exclusive
  - The difference between `js/css_name` and `Media.js/css` is that `js/css_name` will be treated
    specially (e.g. apply scoped CSS, etc), while `Media.js/css` is not post-processed in any way.
- Lower-case the settings for `ComponentRegistry`, so it's the same casing as the main settings.
  E.g. `CONTEXT_BEHAVIOR` -> `context_behavior`. Because the upper-case variant is only how we refer
  to the settings internally.
- Rename `reload_on_template_change` to `reload_on_file_change`, since it woul now watch all files, not just template files.

...And now onto the actual PR:

---

## Description

`self.input.slots` is empty when component is given slots inside the template using `{% fill %}` tags.

In the UI component library, there's often logic that goes like "render A if slot is given,
or render B if slot is NOT given".

I found that I cannot use `Component.is_filled` for this, because `is_filled` is actually
populated LATER than I need. (This is also one of the topics to discuss, but I'm leaving
this for later). So I have to use `self.input.slots`.

But I found that when a component is defined inside a template, e.g.

```django
{% component "table" %}
    {% fill "headers" %}
    bla bla
    {% endfill %}
{% endcomponent %}
```

Then internally, we store these as `self.fill_content`, and not as `self.input.slots`.

On the other hand, `self.input.slots` is populated when we pass in slots in Python:

```python
Table.render(
    slots={
        "headers": "bla bla",
    },
)
```

So to align the two, I refactored the slots logic, so that the `fill_content` is normalized
as slot functions, and stored under `self.input.slots`.

`fill_content` has not been documented, so should be safe to remove.
