### PR TITLE
fix(docs) Replace `shorthand_component_formatter` with `component_sho…

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ it allows to return either a string or a Template instance.
     {% endcomponent %}
     ```
 
-    While `django_components.shorthand_component_formatter` allows you to write components like so:
+    While `django_components.component_shorthand_formatter` allows you to write components like so:
 
     ```django
     {% button href="..." disabled %}
@@ -2778,7 +2778,7 @@ Click me!
 
 You can change this behaviour in the settings under the [`COMPONENTS.tag_formatter`](#tag-formatter-setting).
 
-For example, if you set the tag formatter to `django_components.shorthand_component_formatter`, the components will use their name as the template tags:
+For example, if you set the tag formatter to `django_components.component_shorthand_formatter`, the components will use their name as the template tags:
 
 ```django
 {% button href="..." disabled %}
@@ -2814,7 +2814,7 @@ django_components provides following predefined TagFormatters:
     {% component "button" href="..." / %}
     ```
 
-- **`ShorthandComponentFormatter` (`django_components.shorthand_component_formatter`)**
+- **`ShorthandComponentFormatter` (`django_components.component_shorthand_formatter`)**
 
     Uses the component name as start tag, and `end<component_name>`
     as an end tag.


### PR DESCRIPTION
…rthand_formatter` in README.md

The proper name appears to be [`component_shorthand_formatter`](https://github.com/EmilStenstrom/django-components/blob/7911daa89ed61132b2a819e74769d748efb3ab03/src/django_components/tag_formatter.py#L222)