### PR TITLE
fix: Do not raise error if multiple slots with same name are flagged as default

### DIFF
--- a/tests/test_templatetags_slot_fill.py
+++ b/tests/test_templatetags_slot_fill.py
@@ -359,7 +359,9 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
         """
         template = Template(template_str)
 
-        with self.assertRaisesMessage(TemplateSyntaxError, "Only one component slot may be marked as 'default', found 'other' and 'main'"):
+        with self.assertRaisesMessage(
+            TemplateSyntaxError, "Only one component slot may be marked as 'default', found 'other' and 'main'"
+        ):
             template.render(Context({}))
 
     @parametrize_context_behavior(["django", "isolated"])


### PR DESCRIPTION
This MR makes it OK if a template contains multiple slots with the same name and flagged as default, e.g.:

```django
{% load component_tags %}
<div>
    <main>{% slot "main" default %}1{% endslot %}</main>
    <div>{% slot "main" default %}2{% endslot %}</div>
</div>
```