### PR TITLE
refactor: pin version of playwright in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,10 @@ deps =
   django50: Django>=5.0,<5.1
   pytest
   pytest-xdist
-  playwright
+  # NOTE: Keep playwright is sync with the version in requirements-ci.txt
+  # Othrwise we get error:
+  # playwright._impl._errors.Error: BrowserType.launch: Executable doesn't exist at /home/runner/.cache/ms-playwright/chromium-1140/chrome-linux/chrome
+  playwright==1.47.0
   requests
   types-requests
   whitenoise
@@ -48,7 +51,8 @@ commands = isort --check-only --diff src/django_components
 [testenv:coverage]
 deps =
   pytest-coverage
-  playwright
+  # NOTE: Keep playwright in sync with the version in requirements-ci.txt
+  playwright==1.47.0
   requests
   types-requests
   whitenoise


### PR DESCRIPTION
Turns out that the error was following:
1. When playwright installs a browser, it caches it at
  `/home/runner/.cache/ms-playwright/chromium-1140/chrome-linux/chrome`
2. The cache path contains the browser version.
3. Different versions of playwright point to different versions of cache. 
4. When we installed the browser, we did it using `requirements-ci.txt`, which pinned playwright version to `1.47.0`.
5. But when we ran tox, tox has it's own set of dependencies specified, adn there the playwright version was not pinned and used newer version of playwright.
6. And so, inside tox, the latter playwright version was used, which expected browser to be installed inside `chromium-1140`. But we installed the browser using the older playwright version, which installed version `chromium-v1134`.

So by pinning the playwright version in `tox.ini`, the two should be in sync