### PR TITLE
refactor: tag formatter - allow fwd slash in end tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
 
 - Slots defined with `{% fill %}` tags are now properly accessible via `self.input.slots` in `get_context_data()`
 
+- Do not raise error if multiple slots with same name are flagged as default
+
+- Allow using forward slash (`/`) when defining custom TagFormatter,
+  e.g. `{% MyComp %}..{% /MyComp %}`.
+
 #### Refactor
 
 - `{% component_dependencies %}` tags are now OPTIONAL - If your components use JS and CSS, but you don't use `{% component_dependencies %}` tags, the JS and CSS will now be, by default, inserted at the end of `<body>` and at the end of `<head>` respectively.

--- a/src/django_components/tag_formatter.py
+++ b/src/django_components/tag_formatter.py
@@ -20,49 +20,149 @@ TAG_RE = re.compile(r"^[{chars}]+$".format(chars=TAG_CHARS))
 
 
 class TagResult(NamedTuple):
-    """The return value from `TagFormatter.parse()`"""
+    """
+    The return value from [`TagFormatter.parse()`](../api#django_components.TagFormatterABC.parse).
+    
+    Read more about [Tag formatter](../../concepts/advanced/tag_formatter).
+    """
 
     component_name: str
-    """Component name extracted from the template tag"""
+    """
+    Component name extracted from the template tag
+    
+    For example, if we had tag
+    
+    ```django
+    {% component "my_comp" key=val key2=val2 %}
+    ```
+
+    Then `component_name` would be `my_comp`.
+    """
+
     tokens: List[str]
-    """Remaining tokens (words) that were passed to the tag, with component name removed"""
+    """
+    Remaining tokens (words) that were passed to the tag, with component name removed
+    
+    For example, if we had tag
+    
+    ```django
+    {% component "my_comp" key=val key2=val2 %}
+    ```
+
+    Then `tokens` would be `['key=val', 'key2=val2']`.
+    """
 
 
 class TagFormatterABC(abc.ABC):
+    """
+    Abstract base class for defining custom tag formatters.
+
+    Tag formatters define how the component tags are used in the template.
+
+    Read more about [Tag formatter](../../concepts/advanced/tag_formatter).
+
+    For example, with the default tag formatter
+    ([`ComponentFormatter`](../tag_formatters#django_components.tag_formatter.ComponentFormatter)),
+    components are written as:
+    
+    ```django
+    {% component "comp_name" %}
+    {% endcomponent %}
+    ```
+    
+    While with the shorthand tag formatter
+    ([`ShorthandComponentFormatter`](../tag_formatters#django_components.tag_formatter.ShorthandComponentFormatter)),
+    components are written as:
+    ```django
+    {% comp_name %}
+    {% endcomp_name %}
+    ```
+
+    **Example:**
+
+    Implementation for `ShorthandComponentFormatter`:
+
+    ```python
+    from djagno_components import TagFormatterABC, TagResult
+
+    class ShorthandComponentFormatter(TagFormatterABC):
+        def start_tag(self, name: str) -> str:
+            return name
+
+        def end_tag(self, name: str) -> str:
+            return f"end{name}"
+
+        def parse(self, tokens: List[str]) -> TagResult:
+            tokens = [*tokens]
+            name = tokens.pop(0)
+            return TagResult(name, tokens)
+    ```
+    """
+
     @abc.abstractmethod
     def start_tag(self, name: str) -> str:
-        """Formats the start tag of a component."""
+        """
+        Formats the start tag of a component.
+
+        Args:
+            name (str): Component's registered name. Required.
+
+        Returns:
+            str: The formatted start tag.
+        """
         ...
 
     @abc.abstractmethod
     def end_tag(self, name: str) -> str:
-        """Formats the end tag of a block component."""
+        """
+        Formats the end tag of a block component.
+
+        Args:
+            name (str): Component's registered name. Required.
+
+        Returns:
+            str: The formatted end tag.
+        """
         ...
 
     @abc.abstractmethod
     def parse(self, tokens: List[str]) -> TagResult:
         """
-        Given the tokens (words) of a component start tag, this function extracts
-        the component name from the tokens list, and returns `TagResult`, which
-        is a tuple of `(component_name, remaining_tokens)`.
+        Given the tokens (words) passed to a component start tag, this function extracts
+        the component name from the tokens list, and returns
+        [`TagResult`](../api#django_components.TagResult),
+        which is a tuple of `(component_name, remaining_tokens)`.
 
-        Example:
+        Args:
+            tokens [List(str]): List of tokens passed to the component tag.
 
-        Given a component declarations:
+        Returns:
+            TagResult: Parsed component name and remaining tokens.
 
-        `{% component "my_comp" key=val key2=val2 %}`
+        **Example:**
 
-        This function receives a list of tokens
+        Assuming we used a component in a template like this:
 
-        `['component', '"my_comp"', 'key=val', 'key2=val2']`
+        ```django
+        {% component "my_comp" key=val key2=val2 %}
+        {% endcomponent %}
+        ```
 
-        `component` is the tag name, which we drop. `"my_comp"` is the component name,
-        but we must remove the extra quotes. And we pass remaining tokens unmodified,
-        as that's the input to the component.
+        This function receives a list of tokens:
 
-        So in the end, we return a tuple:
+        ```python
+        ['component', '"my_comp"', 'key=val', 'key2=val2']
+        ```
 
-        `('my_comp', ['key=val', 'key2=val2'])`
+        - `component` is the tag name, which we drop.
+        - `"my_comp"` is the component name, but we must remove the extra quotes.
+        - The remaining tokens we pass unmodified, as that's the input to the component.
+
+        So in the end, we return:
+
+        ```python
+        TagResult('my_comp', ['key=val', 'key2=val2'])
+        ```
         """
         ...
 
@@ -107,8 +207,8 @@ class InternalTagFormatter:
 
 class ComponentFormatter(TagFormatterABC):
     """
-    The original django_component's component tag formatter, it uses the `component`
-    and `endcomponent` tags, and the component name is gives as the first positional arg.
+    The original django_component's component tag formatter, it uses the `{% component %}`
+    and `{% endcomponent %}` tags, and the component name is given as the first positional arg.
 
     Example as block:
     ```django
@@ -176,9 +276,11 @@ class ComponentFormatter(TagFormatterABC):
 
 class ShorthandComponentFormatter(TagFormatterABC):
     """
-    The component tag formatter that uses `<name>` / `end<name>` tags.
+    The component tag formatter that uses `{% <name> %}` / `{% end<name> %}` tags.
 
-    This is similar to django-web-components and django-slippers syntax.
+    This is similar to [django-web-components](https://github.com/Xzya/django-web-components)
+    and [django-slippers](https://github.com/mixxorz/slippers)
+    syntax.
 
     Example as block:
     ```django
@@ -220,6 +322,6 @@ def get_tag_formatter(registry: "ComponentRegistry") -> InternalTagFormatter:
     return InternalTagFormatter(tag_formatter)
 
 
-# Default formatters
+# Pre-defined formatters
 component_formatter = ComponentFormatter("component")
 component_shorthand_formatter = ShorthandComponentFormatter()

--- a/src/django_components/tag_formatter.py
+++ b/src/django_components/tag_formatter.py
@@ -22,7 +22,7 @@ TAG_RE = re.compile(r"^[{chars}]+$".format(chars=TAG_CHARS))
 class TagResult(NamedTuple):
     """
     The return value from [`TagFormatter.parse()`](../api#django_components.TagFormatterABC.parse).
-    
+
     Read more about [Tag formatter](../../concepts/advanced/tag_formatter).
     """
 
@@ -64,12 +64,12 @@ class TagFormatterABC(abc.ABC):
     For example, with the default tag formatter
     ([`ComponentFormatter`](../tag_formatters#django_components.tag_formatter.ComponentFormatter)),
     components are written as:
-    
+
     ```django
     {% component "comp_name" %}
     {% endcomponent %}
     ```
-    
+
     While with the shorthand tag formatter
     ([`ShorthandComponentFormatter`](../tag_formatters#django_components.tag_formatter.ShorthandComponentFormatter)),
     components are written as:

--- a/src/django_components/tag_formatter.py
+++ b/src/django_components/tag_formatter.py
@@ -13,7 +13,10 @@ if TYPE_CHECKING:
     from django_components.component_registry import ComponentRegistry
 
 
-TAG_RE = re.compile(r"^[{chars}]+$".format(chars=VAR_CHARS))
+# Forward slash is added so it's possible to define components like
+# `{% MyComp %}..{% /MyComp %}`
+TAG_CHARS = VAR_CHARS + r"/"
+TAG_RE = re.compile(r"^[{chars}]+$".format(chars=TAG_CHARS))
 
 
 class TagResult(NamedTuple):
@@ -98,7 +101,7 @@ class InternalTagFormatter:
         if not TAG_RE.match(tag):
             raise ValueError(
                 f"{self.tag_formatter.__class__.__name__} returned an invalid tag for {tag_type}: '{tag}'."
-                f" Tag must contain only following chars: {VAR_CHARS}"
+                f" Tag must contain only following chars: {TAG_CHARS}"
             )
 
 

--- a/src/django_components/tag_formatter.py
+++ b/src/django_components/tag_formatter.py
@@ -29,9 +29,9 @@ class TagResult(NamedTuple):
     component_name: str
     """
     Component name extracted from the template tag
-    
+
     For example, if we had tag
-    
+
     ```django
     {% component "my_comp" key=val key2=val2 %}
     ```
@@ -42,9 +42,9 @@ class TagResult(NamedTuple):
     tokens: List[str]
     """
     Remaining tokens (words) that were passed to the tag, with component name removed
-    
+
     For example, if we had tag
-    
+
     ```django
     {% component "my_comp" key=val key2=val2 %}
     ```

--- a/tests/test_tag_formatter.py
+++ b/tests/test_tag_formatter.py
@@ -268,7 +268,7 @@ class ComponentTagTests(BaseTestCase):
         cases=["django", "isolated"],
         settings={
             "COMPONENTS": {
-                "tag_formatter": SlashEndTagFormatter,
+                "tag_formatter": SlashEndTagFormatter(),
             },
         },
     )

--- a/tests/test_tag_formatter.py
+++ b/tests/test_tag_formatter.py
@@ -19,6 +19,11 @@ class MultiwordBlockEndTagFormatter(ShorthandComponentFormatter):
         return f"end {name}"
 
 
+class SlashEndTagFormatter(ShorthandComponentFormatter):
+    def end_tag(self, name):
+        return f"/{name}"
+
+
 # Create a TagFormatter class to validate the public interface
 def create_validator_tag_formatter(tag_name: str):
     class ValidatorTagFormatter(ShorthandComponentFormatter):
@@ -245,6 +250,46 @@ class ComponentTagTests(BaseTestCase):
             {% simple %}
                 OVERRIDEN!
             {% endsimple %}
+        """
+        )
+        rendered = template.render(Context())
+        self.assertHTMLEqual(
+            rendered,
+            """
+            hello1
+            <div>
+                OVERRIDEN!
+            </div>
+            hello2
+            """,
+        )
+
+    @parametrize_context_behavior(
+        cases=["django", "isolated"],
+        settings={
+            "COMPONENTS": {
+                "tag_formatter": SlashEndTagFormatter,
+            },
+        },
+    )
+    def test_forward_slash_in_end_tag(self):
+        @register("simple")
+        class SimpleComponent(Component):
+            template: types.django_html = """
+                {% load component_tags %}
+                hello1
+                <div>
+                    {% slot "content" default %} SLOT_DEFAULT {% endslot %}
+                </div>
+                hello2
+            """
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% simple %}
+                OVERRIDEN!
+            {% /simple %}
         """
         )
         rendered = template.render(Context())


### PR DESCRIPTION
For the UI component library I was playing around with the idea of defining component similarly to how Vue / React does it - with PascalCase and forward slash to indicate the end tag:

```django
{% MyComp %}
{% /MyComp %}
```

But the forward slash was not recognized. So this MR adds `/` to the set of character allowed for start / end tags.

Also updated docs for tag formatter API.