### PR TITLE
refactor: Use lowercase names for registry settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@
     )
     ```
 
+- The [`ComponentRegistry`](../api#django_components.ComponentRegistry) settings [`RegistrySettings`](../api#django_components.RegistrySettings) were lowercased
+  to align with the global settings:
+  - `RegistrySettings.CONTEXT_BEHAVIOR` -> `RegistrySettings.context_behavior`
+  - `RegistrySettings.TAG_FORMATTER` -> `RegistrySettings.tag_formatter`
+
 #### Fix
 
 - Slots defined with `{% fill %}` tags are now properly accessible via `self.input.slots` in `get_context_data()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,6 @@
     )
     ```
 
-- The [`ComponentRegistry`](../api#django_components.ComponentRegistry) settings [`RegistrySettings`](../api#django_components.RegistrySettings) were lowercased
-  to align with the global settings:
-  - `RegistrySettings.CONTEXT_BEHAVIOR` -> `RegistrySettings.context_behavior`
-  - `RegistrySettings.TAG_FORMATTER` -> `RegistrySettings.tag_formatter`
-
 #### Fix
 
 - Slots defined with `{% fill %}` tags are now properly accessible via `self.input.slots` in `get_context_data()`
@@ -67,6 +62,13 @@
 - `{% component_dependencies %}` tags are now OPTIONAL - If your components use JS and CSS, but you don't use `{% component_dependencies %}` tags, the JS and CSS will now be, by default, inserted at the end of `<body>` and at the end of `<head>` respectively.
 
 - For advanced use cases, use can omit the middleware and instead manage component JS and CSS dependencies yourself with [`render_dependencies`](https://github.com/EmilStenstrom/django-components#render_dependencies-and-deep-dive-into-rendering-js--css-without-the-middleware)
+
+- The [`ComponentRegistry`](../api#django_components.ComponentRegistry) settings [`RegistrySettings`](../api#django_components.RegistrySettings)
+  were lowercased to align with the global settings:
+  - `RegistrySettings.CONTEXT_BEHAVIOR` -> `RegistrySettings.context_behavior`
+  - `RegistrySettings.TAG_FORMATTER` -> `RegistrySettings.tag_formatter`
+
+  The old uppercase settings `CONTEXT_BEHAVIOR` and `TAG_FORMATTER` are deprecated and will be removed in v1.
 
 ## 🚨📢 v0.100
 

--- a/README.md
+++ b/README.md
@@ -1124,8 +1124,8 @@ NOTE: The Library instance can be accessed under `library` attribute of `Compone
 When you are creating an instance of `ComponentRegistry`, you can define the components' behavior within the template.
 
 The registry accepts these settings:
-- `CONTEXT_BEHAVIOR`
-- `TAG_FORMATTER`
+- `context_behavior`
+- `tag_formatter`
 
 ```py
 from django.template import Library
@@ -1135,8 +1135,8 @@ register = library = django.template.Library()
 comp_registry = ComponentRegistry(
     library=library,
     settings=RegistrySettings(
-        CONTEXT_BEHAVIOR="isolated",
-        TAG_FORMATTER="django_components.component_formatter",
+        context_behavior="isolated",
+        tag_formatter="django_components.component_formatter",
     ),
 )
 ```
@@ -3741,17 +3741,17 @@ You can publish and share your components for others to use. Here are the steps 
     comp_registry = ComponentRegistry(
         library=library,
         settings=RegistrySettings(
-            CONTEXT_BEHAVIOR="isolated",
-            TAG_FORMATTER="django_components.component_formatter",
+            context_behavior="isolated",
+            tag_formatter="django_components.component_formatter",
         ),
     )
     ```
 
     As you can see above, this is also the place where we configure how our components should behave, using the `settings` argument. If omitted, default settings are used.
 
-    For library authors, we recommend setting `CONTEXT_BEHAVIOR` to `"isolated"`, so that the state cannot leak into the components, and so the components' behavior is configured solely through the inputs. This means that the components will be more predictable and easier to debug.
+    For library authors, we recommend setting `context_behavior` to `"isolated"`, so that the state cannot leak into the components, and so the components' behavior is configured solely through the inputs. This means that the components will be more predictable and easier to debug.
 
-    Next, you can decide how will others use your components by settingt the `TAG_FORMATTER` options.
+    Next, you can decide how will others use your components by settingt the `tag_formatter` options.
 
     If omitted or set to `"django_components.component_formatter"`,
     your components will be used like this:

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -1,12 +1,14 @@
 import re
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Literal, Tuple, Union
 
 from django.conf import settings
 
 if TYPE_CHECKING:
     from django_components.tag_formatter import TagFormatterABC
+
+ContextBehaviorType = Literal["django", "isolated"]
 
 
 class ContextBehavior(str, Enum):

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -918,7 +918,7 @@ class ComponentNode(BaseNode):
         )
 
         # Prevent outer context from leaking into the template of the component
-        if self.isolated_context or self.registry.settings.CONTEXT_BEHAVIOR == ContextBehavior.ISOLATED:
+        if self.isolated_context or self.registry.settings.context_behavior == ContextBehavior.ISOLATED:
             context = make_isolated_context_copy(context)
 
         output = component._render(

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -72,19 +72,23 @@ class RegistrySettings(NamedTuple):
 
     context_behavior: Optional[ContextBehaviorType] = None
     """
-    Same as the global [`COMPONENTS.context_behavior`](../settings#django_components.app_settings.ComponentsSettings.context_behavior)
+    Same as the global
+    [`COMPONENTS.context_behavior`](../settings#django_components.app_settings.ComponentsSettings.context_behavior)
     setting, but for this registry.
 
-    If omitted, defaults to the global [`COMPONENTS.context_behavior`](../settings#django_components.app_settings.ComponentsSettings.context_behavior)
+    If omitted, defaults to the global
+    [`COMPONENTS.context_behavior`](../settings#django_components.app_settings.ComponentsSettings.context_behavior)
     setting.
     """
 
     tag_formatter: Optional[Union["TagFormatterABC", str]] = None
     """
-    Same as the global [`COMPONENTS.tag_formatter`](../settings#django_components.app_settings.ComponentsSettings.tag_formatter)
+    Same as the global
+    [`COMPONENTS.tag_formatter`](../settings#django_components.app_settings.ComponentsSettings.tag_formatter)
     setting, but for this registry.
 
-    If omitted, defaults to the global [`COMPONENTS.tag_formatter`](../settings#django_components.app_settings.ComponentsSettings.tag_formatter)
+    If omitted, defaults to the global
+    [`COMPONENTS.tag_formatter`](../settings#django_components.app_settings.ComponentsSettings.tag_formatter)
     setting.
     """
 
@@ -121,7 +125,8 @@ class ComponentRegistry:
     See [Registering components](../../concepts/advanced/component_registry).
 
     Args:
-        library (Library, optional): Django [`Library`](https://docs.djangoproject.com/en/5.1/howto/custom-template-tags/#code-layout)\
+        library (Library, optional): Django\
+            [`Library`](https://docs.djangoproject.com/en/5.1/howto/custom-template-tags/#code-layout)\
             associated with this registry. If omitted, the default Library instance from django_components is used.
         settings (Union[RegistrySettings, Callable[[ComponentRegistry], RegistrySettings]], optional): Configure\
             how the components registered with this registry will behave when rendered.\
@@ -156,24 +161,24 @@ class ComponentRegistry:
     # Using registry to share components
 
     You can use component registry for isolating or "packaging" components:
-     
+
     1. Create new instance of `ComponentRegistry` and Library:
         ```django
         my_comps = Library()
-        my_comps_reg = ComponentRegistry(library=my_comps)    
+        my_comps_reg = ComponentRegistry(library=my_comps)
         ```
-    
+
     2. Register components to the registry:
         ```django
         my_comps_reg.register("my_button", ButtonComponent)
         my_comps_reg.register("my_card", CardComponent)
         ```
-    
+
     3. In your target project, load the Library associated with the registry:
         ```django
         {% load my_comps %}
         ```
-        
+
     4. Use the registered components in your templates:
         ```django
         {% component "button" %}
@@ -477,7 +482,7 @@ def register(name: str, registry: Optional[ComponentRegistry] = None) -> Callabl
             from within a template when using the [`{% component %}`](../template_tags#component) tag. Required.
         registry (ComponentRegistry, optional): Specify the [registry](./#django_components.ComponentRegistry)\
             to which to register this component. If omitted, component is registered to the default registry.
-            
+
     Raises:
         AlreadyRegistered: If there is already a component registered under the same name.
 

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -24,6 +24,7 @@ class AlreadyRegistered(Exception):
     but it's already registered with given
     [ComponentRegistry](../api#django_components.ComponentRegistry).
     """
+
     pass
 
 
@@ -33,6 +34,7 @@ class NotRegistered(Exception):
     but it's NOT registered with given
     [ComponentRegistry](../api#django_components.ComponentRegistry).
     """
+
     pass
 
 
@@ -346,7 +348,7 @@ class ComponentRegistry:
 
         Returns:
             Type[Component]: The component class registered under the given name.
-        
+
         **Raises:**
 
         - [`NotRegistered`](../exceptions#django_components.NotRegistered)

--- a/src/django_components/component_registry.py
+++ b/src/django_components/component_registry.py
@@ -81,8 +81,36 @@ class RegistrySettings(NamedTuple):
     setting.
     """
 
+    # TODO_REMOVE_IN_V1
+    CONTEXT_BEHAVIOR: Optional[ContextBehaviorType] = None
+    """
+    _Deprecated. Use `context_behavior` instead. Will be removed in v1._
+
+    Same as the global
+    [`COMPONENTS.context_behavior`](../settings#django_components.app_settings.ComponentsSettings.context_behavior)
+    setting, but for this registry.
+
+    If omitted, defaults to the global
+    [`COMPONENTS.context_behavior`](../settings#django_components.app_settings.ComponentsSettings.context_behavior)
+    setting.
+    """
+
     tag_formatter: Optional[Union["TagFormatterABC", str]] = None
     """
+    Same as the global
+    [`COMPONENTS.tag_formatter`](../settings#django_components.app_settings.ComponentsSettings.tag_formatter)
+    setting, but for this registry.
+
+    If omitted, defaults to the global
+    [`COMPONENTS.tag_formatter`](../settings#django_components.app_settings.ComponentsSettings.tag_formatter)
+    setting.
+    """
+
+    # TODO_REMOVE_IN_V1
+    TAG_FORMATTER: Optional[Union["TagFormatterABC", str]] = None
+    """
+    _Deprecated. Use `tag_formatter` instead. Will be removed in v1._
+
     Same as the global
     [`COMPONENTS.tag_formatter`](../settings#django_components.app_settings.ComponentsSettings.tag_formatter)
     setting, but for this registry.
@@ -243,10 +271,16 @@ class ComponentRegistry:
                 else:
                     settings_input = self._settings_input
 
+                if settings_input:
+                    context_behavior = settings_input.context_behavior or settings_input.CONTEXT_BEHAVIOR
+                    tag_formatter = settings_input.tag_formatter or settings_input.TAG_FORMATTER
+                else:
+                    context_behavior = None
+                    tag_formatter = None
+
                 return InternalRegistrySettings(
-                    context_behavior=(settings_input and settings_input.context_behavior)
-                    or app_settings.CONTEXT_BEHAVIOR.value,
-                    tag_formatter=(settings_input and settings_input.tag_formatter) or app_settings.TAG_FORMATTER,
+                    context_behavior=context_behavior or app_settings.CONTEXT_BEHAVIOR.value,
+                    tag_formatter=tag_formatter or app_settings.TAG_FORMATTER,
                 )
 
             self._settings = get_settings

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -193,12 +193,12 @@ class SlotNode(BaseNode):
             return context
 
         registry: "ComponentRegistry" = context[_REGISTRY_CONTEXT_KEY]
-        if registry.settings.CONTEXT_BEHAVIOR == ContextBehavior.DJANGO:
+        if registry.settings.context_behavior == ContextBehavior.DJANGO:
             return context
-        elif registry.settings.CONTEXT_BEHAVIOR == ContextBehavior.ISOLATED:
+        elif registry.settings.context_behavior == ContextBehavior.ISOLATED:
             return context[_ROOT_CTX_CONTEXT_KEY]
         else:
-            raise ValueError(f"Unknown value for CONTEXT_BEHAVIOR: '{registry.settings.CONTEXT_BEHAVIOR}'")
+            raise ValueError(f"Unknown value for context_behavior: '{registry.settings.context_behavior}'")
 
     def resolve_kwargs(
         self,

--- a/src/django_components/tag_formatter.py
+++ b/src/django_components/tag_formatter.py
@@ -312,7 +312,7 @@ class ShorthandComponentFormatter(TagFormatterABC):
 def get_tag_formatter(registry: "ComponentRegistry") -> InternalTagFormatter:
     """Returns an instance of the currently configured component tag formatter."""
     # Allow users to configure the component TagFormatter
-    formatter_cls_or_str = registry.settings.TAG_FORMATTER
+    formatter_cls_or_str = registry.settings.tag_formatter
 
     if isinstance(formatter_cls_or_str, str):
         tag_formatter: TagFormatterABC = import_string(formatter_cls_or_str)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -150,8 +150,8 @@ class MultipleComponentRegistriesTest(BaseTestCase):
         registry_a = ComponentRegistry(
             library=library_a,
             settings=RegistrySettings(
-                CONTEXT_BEHAVIOR=ContextBehavior.ISOLATED,
-                TAG_FORMATTER=component_shorthand_formatter,
+                context_behavior=ContextBehavior.ISOLATED.value,
+                tag_formatter=component_shorthand_formatter,
             ),
         )
 
@@ -159,8 +159,8 @@ class MultipleComponentRegistriesTest(BaseTestCase):
         registry_b = ComponentRegistry(
             library=library_b,
             settings=RegistrySettings(
-                CONTEXT_BEHAVIOR=ContextBehavior.DJANGO,
-                TAG_FORMATTER=component_formatter,
+                context_behavior=ContextBehavior.DJANGO.value,
+                tag_formatter=component_formatter,
             ),
         )
 


### PR DESCRIPTION
In this MR I suggest to rename the inputs passed to ComponentRegistry, from all-uppercase to lowercase. The reason is so that the API is aligned with the global settings, which are also all-lowercase. I noticed this difference when I was writing up the documentation.

The reason why I originally defined the settings as uppercase was because I got confused by our internal `app_settings`, where the fields are defined as upper case.

NOTE: This MR has similar structure as the last one - One commit is the change itself, the other is documentation.