### PR TITLE
feat: define settings as a data class for type hints, intellisense, and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@
     )
     ```
 
+#### Feat
+
+- Intellisense and mypy validation for settings:
+  
+  Instead of defining the `COMPONENTS` settings as a plain dict, you can use `ComponentsSettings`:
+
+  ```py
+  # settings.py
+  from django_components import ComponentsSettings
+
+  COMPONENTS = ComponentsSettings(
+      autodiscover=True,
+      ...
+  )
+  ```
+
 #### Fix
 
 - Slots defined with `{% fill %}` tags are now properly accessible via `self.input.slots` in `get_context_data()`

--- a/sampleproject/sampleproject/settings.py
+++ b/sampleproject/sampleproject/settings.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from typing import List
 
+from django_components import ComponentsSettings
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -88,14 +90,14 @@ STATICFILES_FINDERS = [
 
 WSGI_APPLICATION = "sampleproject.wsgi.application"
 
-COMPONENTS = {
-    #    "autodiscover": True,
-    "dirs": [BASE_DIR / "components"],
-    #    "app_dirs": ["components"],
-    #    "libraries": [],
-    #    "template_cache_size": 128,
-    #    "context_behavior": "isolated",  # "django" | "isolated"
-}
+COMPONENTS = ComponentsSettings(
+    #    autodiscover=True,
+    dirs=[BASE_DIR / "components"],
+    #    app_dirs=["components"],
+    #    libraries=[],
+    #    template_cache_size=128,
+    #    context_behavior="isolated",  # "django" | "isolated"
+)
 
 
 # Database

--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -4,7 +4,7 @@
 # NOTE: Middleware is exposed via django_components.middleware
 # NOTE: Some of the documentation is generated based on these exports
 # isort: off
-from django_components.app_settings import ContextBehavior
+from django_components.app_settings import ContextBehavior, ComponentsSettings
 from django_components.autodiscovery import autodiscover, import_libraries
 from django_components.component import Component, ComponentVars, ComponentView
 from django_components.component_registry import (
@@ -39,6 +39,7 @@ __all__ = [
     "autodiscover",
     "cached_template",
     "ContextBehavior",
+    "ComponentsSettings",
     "Component",
     "ComponentFormatter",
     "ComponentRegistry",

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -147,7 +147,7 @@ class Dynamic(Generic[T]):
 #       for `COMPONENTS.dirs`, we do it lazily.
 # NOTE 2: We show the defaults in the documentation, together with the comments
 #        (except for the `Dynamic` instances and comments like `type: ignore`).
-#        So `fmt: off` turns off Black formatting and `--snippet:defaults--` allows
+#        So `fmt: off` turns off Black formatting and `snippet:defaults` allows
 #        us to extract the snippet from the file.
 #
 # fmt: off

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -124,7 +124,7 @@ class ComponentsSettings(NamedTuple):
     dynamic_component_name: Optional[str] = None
     libraries: Optional[List[str]] = None
     multiline_tags: Optional[bool] = None
-    reload_on_file_change: Optional[bool] = None
+    reload_on_template_change: Optional[bool] = None
     static_files_allowed: Optional[List[Union[str, re.Pattern]]] = None
     forbidden_static_files: Optional[List[Union[str, re.Pattern]]] = None
     tag_formatter: Optional[Union["TagFormatterABC", str]] = None
@@ -162,7 +162,7 @@ defaults = ComponentsSettings(
     dynamic_component_name="dynamic",
     libraries=[],  # E.g. ["mysite.components.forms", ...]
     multiline_tags=True,
-    reload_on_file_change=False,
+    reload_on_template_change=False,
     static_files_allowed=[
         ".css",
         ".js", ".jsx", ".ts", ".tsx",
@@ -221,8 +221,8 @@ class InternalSettings:
         return default(self._settings.multiline_tags, cast(bool, defaults.multiline_tags))
 
     @property
-    def RELOAD_ON_FILE_CHANGE(self) -> bool:
-        return default(self._settings.reload_on_file_change, cast(bool, defaults.reload_on_file_change))
+    def RELOAD_ON_TEMPLATE_CHANGE(self) -> bool:
+        return default(self._settings.reload_on_template_change, cast(bool, defaults.reload_on_template_change))
 
     @property
     def TEMPLATE_CACHE_SIZE(self) -> int:

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -200,7 +200,7 @@ class InternalSettings:
     def DIRS(self) -> Sequence[Union[str, PathLike, Tuple[str, str], Tuple[str, PathLike]]]:
         # For DIRS we use a getter, because default values uses Django settings,
         # which may not yet be initialized at the time these settings are generated.
-        default_fn = cast(Dynamic[Sequence[str | tuple[str, str]]], defaults.dirs)
+        default_fn = cast(Dynamic[Sequence[Union[str, Tuple[str, str]]]], defaults.dirs)
         default_dirs = default_fn.getter()
         return default(self._settings.dirs, default_dirs)
 

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -1,6 +1,7 @@
 import re
 from dataclasses import dataclass
 from enum import Enum
+from os import PathLike
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -117,7 +118,7 @@ class ContextBehavior(str, Enum):
 # or the defaults do NOT match this, they should be updated.
 class ComponentsSettings(NamedTuple):
     autodiscover: Optional[bool] = None
-    dirs: Optional[Sequence[Union[str, Tuple[str, str]]]] = None
+    dirs: Optional[Sequence[Union[str, PathLike, Tuple[str, str], Tuple[str, PathLike]]]] = None
     app_dirs: Optional[Sequence[str]] = None
     context_behavior: Optional[ContextBehaviorType] = None
     dynamic_component_name: Optional[str] = None
@@ -196,7 +197,7 @@ class InternalSettings:
         return default(self._settings.autodiscover, cast(bool, defaults.autodiscover))
 
     @property
-    def DIRS(self) -> Sequence[Union[str, Tuple[str, str]]]:
+    def DIRS(self) -> Sequence[Union[str, PathLike, Tuple[str, str], Tuple[str, PathLike]]]:
         # For DIRS we use a getter, because default values uses Django settings,
         # which may not yet be initialized at the time these settings are generated.
         default_fn = cast(Dynamic[Sequence[str | tuple[str, str]]], defaults.dirs)

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -154,7 +154,7 @@ class Dynamic(Generic[T]):
 # --snippet:defaults--
 defaults = ComponentsSettings(
     autodiscover=True,
-    context_behavior=ContextBehavior.DJANGO.value, # "django" | "isolated"
+    context_behavior=ContextBehavior.DJANGO.value,  # "django" | "isolated"
     # Root-level "components" dirs, e.g. `/path/to/proj/components/`
     dirs=Dynamic(lambda: [Path(settings.BASE_DIR) / "components"]),  # type: ignore[arg-type]
     # App-level "components" dirs, e.g. `[app]/components/`
@@ -168,7 +168,7 @@ defaults = ComponentsSettings(
         ".js", ".jsx", ".ts", ".tsx",
         # Images
         ".apng", ".png", ".avif", ".gif", ".jpg",
-        ".jpeg",  ".jfif", ".pjpeg", ".pjp", ".svg",
+        ".jpeg", ".jfif", ".pjpeg", ".pjp", ".svg",
         ".webp", ".bmp", ".ico", ".cur", ".tif", ".tiff",
         # Fonts
         ".eot", ".ttf", ".woff", ".otf", ".svg",

--- a/src/django_components/util/misc.py
+++ b/src/django_components/util/misc.py
@@ -1,12 +1,15 @@
 import glob
 import re
 from pathlib import Path
-from typing import Any, Callable, List, Sequence, Type, Union
+from typing import Any, Callable, List, Optional, Sequence, Type, TypeVar, Union
 
 from django.template.defaultfilters import escape
 from django.utils.autoreload import autoreload_started
 
 from django_components.util.nanoid import generate
+
+
+T = TypeVar("T")
 
 
 # Based on nanoid implementation from
@@ -90,3 +93,7 @@ def escape_js_string_literal(js: str) -> str:
 
     escaped_js = JS_STRING_LITERAL_SPECIAL_CHARS_REGEX.sub(on_replace_match, escaped_js)
     return escaped_js
+
+
+def default(val: Optional[T], default: T) -> T:
+    return val if val is not None else default

--- a/src/django_components/util/misc.py
+++ b/src/django_components/util/misc.py
@@ -8,7 +8,6 @@ from django.utils.autoreload import autoreload_started
 
 from django_components.util.nanoid import generate
 
-
 T = TypeVar("T")
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,12 +2,13 @@ from pathlib import Path
 
 from django.test import override_settings
 
+from django_components import ComponentsSettings
 from django_components.app_settings import app_settings
 
 from .django_test_setup import setup_test_config
 from .testutils import BaseTestCase
 
-setup_test_config()
+setup_test_config(components={"autodiscover": False})
 
 
 class SettingsTestCase(BaseTestCase):
@@ -27,3 +28,11 @@ class SettingsTestCase(BaseTestCase):
     @override_settings(BASE_DIR=Path("base_dir"))
     def test_works_when_base_dir_is_path(self):
         self.assertEqual(app_settings.DIRS, [Path("base_dir/components")])
+
+    @override_settings(COMPONENTS={"context_behavior": "isolated"})
+    def test_settings_as_dict(self):
+        self.assertEqual(app_settings.CONTEXT_BEHAVIOR, "isolated")
+
+    @override_settings(COMPONENTS=ComponentsSettings(context_behavior="isolated"))
+    def test_settings_as_instance(self):
+        self.assertEqual(app_settings.CONTEXT_BEHAVIOR, "isolated")


### PR DESCRIPTION
I wanted the settings documentation to live close to the code, using the docstrings to generate the API reference docs. However, the way we parsed the django_component's settings, I wasn't able to access the settings fields. There is the `AppSettings` class, but its fields do not match the fields that the user fills in (e.g. user supplies `app_dirs`, while we access it as `app_settings.APP_DIRS`.

So what I did was to define a class (`ComponentsSettings`) that's purely for defining the shape of the user-facing settings. And this becomes the source of truth of what settings are there. This class can then have its fields documented with docstrings, and this can be then used to generate the settings docs. Plus, it also offers users intellisense and type checking if users decide to use `ComponentSettings` to define the settings instead of a plain dict.

So in users' Django settings, instead of

```py
COMPONENTS = {
    autodiscover: False,
}
```

Then can now do

```py
from django_components import ComponentsSettings

COMPONENTS = ComponentsSettings(
    autodiscover=False,
)
```

Users can still supply only the plain dict, so this is not a breaking change.