### PR TITLE
refactor: fix reload-on-change logic, expose autodiscover's dirs-getting logic, rename settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@
   )
   ```
 
+- Use `get_component_dirs()` and `get_component_files()` to get the same list of dirs / files that would be imported by `autodiscover()`, but without actually
+importing them.
+
 #### Fix
 
 - Slots defined with `{% fill %}` tags are now properly accessible via `self.input.slots` in `get_context_data()`
@@ -85,6 +88,17 @@
   - `RegistrySettings.TAG_FORMATTER` -> `RegistrySettings.tag_formatter`
 
   The old uppercase settings `CONTEXT_BEHAVIOR` and `TAG_FORMATTER` are deprecated and will be removed in v1.
+
+- The setting `reload_on_template_change` was renamed to
+  [`reload_on_file_change`](../settings#django_components.app_settings.ComponentsSettings#reload_on_file_change).
+  And now it triggers server reload when any file in `BASE_DIR` changes. The old name `reload_on_template_change`
+  is deprecated and will be removed in v1.
+
+- The setting `forbidden_static_files` was renamed to
+  [`static_files_forbidden`](../settings#django_components.app_settings.ComponentsSettings#static_files_forbidden)
+  to align with [`static_files_allowed`](../settings#django_components.app_settings.ComponentsSettings#static_files_allowed)
+  The old name `forbidden_static_files` is deprecated and will be removed in v1.
+
 
 ## 🚨📢 v0.100
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ importing them.
 
 - The setting `reload_on_template_change` was renamed to
   [`reload_on_file_change`](../settings#django_components.app_settings.ComponentsSettings#reload_on_file_change).
-  And now it triggers server reload when any file in `BASE_DIR` changes. The old name `reload_on_template_change`
+  And now it properly triggers server reload when any file in the component dirs change. The old name `reload_on_template_change`
   is deprecated and will be removed in v1.
 
 - The setting `forbidden_static_files` was renamed to

--- a/src/django_components/__init__.py
+++ b/src/django_components/__init__.py
@@ -29,6 +29,7 @@ from django_components.tag_formatter import (
 )
 from django_components.template import cached_template
 import django_components.types as types
+from django_components.util.loader import ComponentFileEntry, get_component_dirs, get_component_files
 from django_components.util.types import EmptyTuple, EmptyDict
 
 # isort: on
@@ -41,6 +42,7 @@ __all__ = [
     "ContextBehavior",
     "ComponentsSettings",
     "Component",
+    "ComponentFileEntry",
     "ComponentFormatter",
     "ComponentRegistry",
     "ComponentVars",
@@ -50,6 +52,8 @@ __all__ = [
     "DynamicComponent",
     "EmptyTuple",
     "EmptyDict",
+    "get_component_dirs",
+    "get_component_files",
     "import_libraries",
     "NotRegistered",
     "register",

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -124,9 +124,17 @@ class ComponentsSettings(NamedTuple):
     dynamic_component_name: Optional[str] = None
     libraries: Optional[List[str]] = None
     multiline_tags: Optional[bool] = None
+    # TODO_REMOVE_IN_V1
     reload_on_template_change: Optional[bool] = None
+    """Deprecated. Use `reload_on_file_change` instead."""
+
+    reload_on_file_change: Optional[bool] = None
     static_files_allowed: Optional[List[Union[str, re.Pattern]]] = None
+    # TODO_REMOVE_IN_V1
     forbidden_static_files: Optional[List[Union[str, re.Pattern]]] = None
+    """Deprecated. Use `static_files_forbidden` instead."""
+
+    static_files_forbidden: Optional[List[Union[str, re.Pattern]]] = None
     tag_formatter: Optional[Union["TagFormatterABC", str]] = None
     template_cache_size: Optional[int] = None
 
@@ -162,7 +170,7 @@ defaults = ComponentsSettings(
     dynamic_component_name="dynamic",
     libraries=[],  # E.g. ["mysite.components.forms", ...]
     multiline_tags=True,
-    reload_on_template_change=False,
+    reload_on_file_change=False,
     static_files_allowed=[
         ".css",
         ".js", ".jsx", ".ts", ".tsx",
@@ -173,7 +181,7 @@ defaults = ComponentsSettings(
         # Fonts
         ".eot", ".ttf", ".woff", ".otf", ".svg",
     ],
-    forbidden_static_files=[
+    static_files_forbidden=[
         # See https://marketplace.visualstudio.com/items?itemName=junstyle.vscode-django-support
         ".html", ".django", ".dj", ".tpl",
         # Python files
@@ -221,8 +229,13 @@ class InternalSettings:
         return default(self._settings.multiline_tags, cast(bool, defaults.multiline_tags))
 
     @property
-    def RELOAD_ON_TEMPLATE_CHANGE(self) -> bool:
-        return default(self._settings.reload_on_template_change, cast(bool, defaults.reload_on_template_change))
+    def RELOAD_ON_FILE_CHANGE(self) -> bool:
+        val = self._settings.reload_on_file_change
+        # TODO_REMOVE_IN_V1
+        if val is None:
+            val = self._settings.reload_on_template_change
+
+        return default(val, cast(bool, defaults.reload_on_file_change))
 
     @property
     def TEMPLATE_CACHE_SIZE(self) -> int:
@@ -234,7 +247,12 @@ class InternalSettings:
 
     @property
     def STATIC_FILES_FORBIDDEN(self) -> Sequence[Union[str, re.Pattern]]:
-        return default(self._settings.forbidden_static_files, cast(List[str], defaults.forbidden_static_files))
+        val = self._settings.static_files_forbidden
+        # TODO_REMOVE_IN_V1
+        if val is None:
+            val = self._settings.forbidden_static_files
+
+        return default(val, cast(List[str], defaults.static_files_forbidden))
 
     @property
     def CONTEXT_BEHAVIOR(self) -> ContextBehavior:

--- a/src/django_components/apps.py
+++ b/src/django_components/apps.py
@@ -56,7 +56,7 @@ def _watch_component_files_for_autoreload() -> None:
     component_dirs = set(get_component_dirs())
 
     def template_changed(sender: Any, file_path: Path, **kwargs: Any) -> None:
-        # Reload dev server if any of the file within `COMPONENTS.dirs` or `COMPONENTS.app_dirs` changed
+        # Reload dev server if any of the files within `COMPONENTS.dirs` or `COMPONENTS.app_dirs` changed
         for dir_path in file_path.parents:
             if dir_path in component_dirs:
                 trigger_reload(file_path)

--- a/src/django_components/apps.py
+++ b/src/django_components/apps.py
@@ -1,6 +1,6 @@
 import re
-from typing import Any
 from pathlib import Path
+from typing import Any
 
 from django.apps import AppConfig
 from django.utils.autoreload import file_changed, trigger_reload

--- a/src/django_components/component_media.py
+++ b/src/django_components/component_media.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, MutableMapping, Opt
 from django.forms.widgets import Media, MediaDefiningClass
 from django.utils.safestring import SafeData
 
-from django_components.template_loader import get_component_dirs
+from django_components.util.loader import get_component_dirs
 from django_components.util.logger import logger
 
 if TYPE_CHECKING:

--- a/src/django_components/finders.py
+++ b/src/django_components/finders.py
@@ -9,7 +9,7 @@ from django.core.files.storage import FileSystemStorage
 from django.utils._os import safe_join
 
 from django_components.app_settings import app_settings
-from django_components.template_loader import get_component_dirs
+from django_components.util.loader import get_component_dirs
 from django_components.util.misc import any_regex_match, no_regex_match
 
 # To keep track on which directories the finder has searched the static files.
@@ -29,7 +29,7 @@ class ComponentsFileSystemFinder(BaseFinder):
     Differences:
     - This finder uses `COMPONENTS.dirs` setting to locate files instead of `STATICFILES_DIRS`.
     - Whether a file within `COMPONENTS.dirs` is considered a STATIC file is configured
-      by `COMPONENTS.static_files_allowed` and `COMPONENTS.forbidden_static_files`.
+      by `COMPONENTS.static_files_allowed` and `COMPONENTS.static_files_forbidden`.
     - If `COMPONENTS.dirs` is not set, defaults to `settings.BASE_DIR / "components"`
     """
 

--- a/src/django_components/template_loader.py
+++ b/src/django_components/template_loader.py
@@ -3,20 +3,13 @@ Template loader that loads templates from each Django app's "components" directo
 """
 
 from pathlib import Path
-from typing import List, Optional, Set
+from typing import List
 
-from django.apps import apps
-from django.conf import settings
-from django.template.engine import Engine
 from django.template.loaders.filesystem import Loader as FilesystemLoader
 
-from django_components.app_settings import app_settings
-from django_components.util.logger import logger
+from django_components.util.loader import get_component_dirs
 
 
-# This is the heart of all features that deal with filesystem and file lookup.
-# Autodiscovery, Django template resolution, static file resolution - They all
-# depend on this loader.
 class Loader(FilesystemLoader):
     def get_dirs(self, include_apps: bool = True) -> List[Path]:
         """
@@ -32,72 +25,4 @@ class Loader(FilesystemLoader):
 
         `BASE_DIR` setting is required.
         """
-        # Allow to configure from settings which dirs should be checked for components
-        component_dirs = app_settings.DIRS
-
-        # TODO_REMOVE_IN_V1
-        is_legacy_paths = (
-            # Use value of `STATICFILES_DIRS` ONLY if `COMPONENT.dirs` not set
-            not getattr(settings, "COMPONENTS", {}).get("dirs", None) is not None
-            and hasattr(settings, "STATICFILES_DIRS")
-            and settings.STATICFILES_DIRS
-        )
-        if is_legacy_paths:
-            # NOTE: For STATICFILES_DIRS, we use the defaults even for empty list.
-            # We don't do this for COMPONENTS.dirs, so user can explicitly specify "NO dirs".
-            component_dirs = settings.STATICFILES_DIRS or [settings.BASE_DIR / "components"]
-        source = "STATICFILES_DIRS" if is_legacy_paths else "COMPONENTS.dirs"
-
-        logger.debug(
-            "Template loader will search for valid template dirs from following options:\n"
-            + "\n".join([f" - {str(d)}" for d in component_dirs])
-        )
-
-        # Add `[app]/[APP_DIR]` to the directories. This is, by default `[app]/components`
-        app_paths: List[Path] = []
-        if include_apps:
-            for conf in apps.get_app_configs():
-                for app_dir in app_settings.APP_DIRS:
-                    comps_path = Path(conf.path).joinpath(app_dir)
-                    if comps_path.exists():
-                        app_paths.append(comps_path)
-
-        directories: Set[Path] = set(app_paths)
-
-        # Validate and add other values from the config
-        for component_dir in component_dirs:
-            # Consider tuples for STATICFILES_DIRS (See #489)
-            # See https://docs.djangoproject.com/en/5.0/ref/settings/#prefixes-optional
-            if isinstance(component_dir, (tuple, list)):
-                component_dir = component_dir[1]
-            try:
-                Path(component_dir)
-            except TypeError:
-                logger.warning(
-                    f"{source} expected str, bytes or os.PathLike object, or tuple/list of length 2. "
-                    f"See Django documentation for STATICFILES_DIRS. Got {type(component_dir)} : {component_dir}"
-                )
-                continue
-
-            if not Path(component_dir).is_absolute():
-                raise ValueError(f"{source} must contain absolute paths, got '{component_dir}'")
-            else:
-                directories.add(Path(component_dir).resolve())
-
-        logger.debug(
-            "Template loader matched following template dirs:\n" + "\n".join([f" - {str(d)}" for d in directories])
-        )
-        return list(directories)
-
-
-def get_component_dirs(include_apps: bool = True, engine: Optional[Engine] = None) -> List[Path]:
-    """
-    Helper for using django_component's FilesystemLoader class to obtain a list
-    of directories where component python files may be defined.
-    """
-    current_engine = engine
-    if current_engine is None:
-        current_engine = Engine.get_default()
-
-    loader = Loader(current_engine)
-    return loader.get_dirs(include_apps)
+        return get_component_dirs(include_apps)

--- a/src/django_components/util/loader.py
+++ b/src/django_components/util/loader.py
@@ -1,0 +1,229 @@
+import glob
+import os
+from pathlib import Path
+from typing import List, NamedTuple, Optional, Set, Union
+
+from django.apps import apps
+from django.conf import settings
+
+from django_components.util.logger import logger
+from django_components.app_settings import app_settings
+
+
+def get_component_dirs(include_apps: bool = True) -> List[Path]:
+    """
+    Get directories that may contain component files.
+
+    This is the heart of all features that deal with filesystem and file lookup.
+    Autodiscovery, Django template resolution, static file resolution - They all use this.
+
+    Args:
+        include_apps (bool, optional): Include directories from installed Django apps.\
+            Defaults to `True`.
+
+    Returns:
+        List[Path]: A list of directories that may contain component files.
+
+    `get_component_dirs()` searches for dirs set in
+    [`COMPONENTS.dirs`](../settings#django_components.app_settings.ComponentsSettings.dirs)
+    settings. If none set, defaults to searching for a `"components"` app.
+
+    In addition to that, also all installed Django apps are checked whether they contain
+    directories as set in
+    [`COMPONENTS.app_dirs`](../settings#django_components.app_settings.ComponentsSettings.app_dirs)
+    (e.g. `[app]/components`).
+
+    **Notes:**
+
+    - Paths that do not point to directories are ignored.
+
+    - `BASE_DIR` setting is required.
+
+    - The paths in [`COMPONENTS.dirs`](../settings#django_components.app_settings.ComponentsSettings.dirs)
+        must be absolute paths.
+    """
+    # Allow to configure from settings which dirs should be checked for components
+    component_dirs = app_settings.DIRS
+
+    # TODO_REMOVE_IN_V1
+    is_legacy_paths = (
+        # Use value of `STATICFILES_DIRS` ONLY if `COMPONENT.dirs` not set
+        getattr(settings, "COMPONENTS", {}).get("dirs", None) is None
+        and hasattr(settings, "STATICFILES_DIRS")
+        and settings.STATICFILES_DIRS
+    )
+    if is_legacy_paths:
+        # NOTE: For STATICFILES_DIRS, we use the defaults even for empty list.
+        # We don't do this for COMPONENTS.dirs, so user can explicitly specify "NO dirs".
+        component_dirs = settings.STATICFILES_DIRS or [settings.BASE_DIR / "components"]
+    source = "STATICFILES_DIRS" if is_legacy_paths else "COMPONENTS.dirs"
+
+    logger.debug(
+        "get_component_dirs will search for valid dirs from following options:\n"
+        + "\n".join([f" - {str(d)}" for d in component_dirs])
+    )
+
+    # Add `[app]/[APP_DIR]` to the directories. This is, by default `[app]/components`
+    app_paths: List[Path] = []
+    if include_apps:
+        for conf in apps.get_app_configs():
+            for app_dir in app_settings.APP_DIRS:
+                comps_path = Path(conf.path).joinpath(app_dir)
+                if comps_path.exists():
+                    app_paths.append(comps_path)
+
+    directories: Set[Path] = set(app_paths)
+
+    # Validate and add other values from the config
+    for component_dir in component_dirs:
+        # Consider tuples for STATICFILES_DIRS (See #489)
+        # See https://docs.djangoproject.com/en/5.0/ref/settings/#prefixes-optional
+        if isinstance(component_dir, (tuple, list)):
+            component_dir = component_dir[1]
+        try:
+            Path(component_dir)
+        except TypeError:
+            logger.warning(
+                f"{source} expected str, bytes or os.PathLike object, or tuple/list of length 2. "
+                f"See Django documentation for STATICFILES_DIRS. Got {type(component_dir)} : {component_dir}"
+            )
+            continue
+
+        if not Path(component_dir).is_absolute():
+            raise ValueError(f"{source} must contain absolute paths, got '{component_dir}'")
+        else:
+            directories.add(Path(component_dir).resolve())
+
+    logger.debug(
+        "get_component_dirs matched following template dirs:\n" + "\n".join([f" - {str(d)}" for d in directories])
+    )
+    return list(directories)
+
+
+class ComponentFileEntry(NamedTuple):
+    """Result returned by [`get_component_files()`](../api#django_components.get_component_files)."""
+    dot_path: str
+    """The python import path for the module. E.g. `app.components.mycomp`"""
+    filepath: Path
+    """The filesystem path to the module. E.g. `/path/to/project/app/components/mycomp.py`"""
+
+
+def get_component_files(suffix: Optional[str] = None) -> List[ComponentFileEntry]:
+    """
+    Search for files within the component directories (as defined in
+    [`get_component_dirs()`](../api#django_components.get_component_dirs)).
+
+    Requires `BASE_DIR` setting to be set.
+
+    Args:
+        suffix (Optional[str], optional): The suffix to search for. E.g. `.py`, `.js`, `.css`.\
+            Defaults to `None`, which will search for all files.
+    
+    Returns:
+        List[ComponentFileEntry] A list of entries that contain both the filesystem path and \
+            the python import path (dot path).
+
+    **Example:**
+
+    ```python
+    from django_components import get_component_files
+
+    modules = get_component_files(".py")
+    ```
+    """
+    search_glob = f"**/*{suffix}" if suffix else "**/*"
+
+    dirs = get_component_dirs(include_apps=False)
+    component_filepaths = _search_dirs(dirs, search_glob)
+
+    if hasattr(settings, "BASE_DIR") and settings.BASE_DIR:
+        project_root = str(settings.BASE_DIR)
+    else:
+        # Fallback for getting the root dir, see https://stackoverflow.com/a/16413955/9788634
+        project_root = os.path.abspath(os.path.dirname(__name__))
+
+    # NOTE: We handle dirs from `COMPONENTS.dirs` and from individual apps separately.
+    modules: List[ComponentFileEntry] = []
+
+    # First let's handle the dirs from `COMPONENTS.dirs`
+    #
+    # Because for dirs in `COMPONENTS.dirs`, we assume they will be nested under `BASE_DIR`,
+    # and that `BASE_DIR` is the current working dir (CWD). So the path relatively to `BASE_DIR`
+    # is ALSO the python import path.
+    for filepath in component_filepaths:
+        module_path = _filepath_to_python_module(filepath, project_root, None)
+        # Ignore files starting with dot `.` or files in dirs that start with dot.
+        #
+        # If any of the parts of the path start with a dot, e.g. the filesystem path
+        # is `./abc/.def`, then this gets converted to python module as `abc..def`
+        #
+        # NOTE: This approach also ignores files:
+        #   - with two dots in the middle (ab..cd.py)
+        #   - an extra dot at the end (abcd..py)
+        #   - files outside of the parent component (../abcd.py).
+        # But all these are NOT valid python modules so that's fine.
+        if ".." in module_path:
+            continue
+
+        entry = ComponentFileEntry(dot_path=module_path, filepath=filepath)
+        modules.append(entry)
+
+    # For for apps, the directories may be outside of the project, e.g. in case of third party
+    # apps. So we have to resolve the python import path relative to the package name / the root
+    # import path for the app.
+    # See https://github.com/EmilStenstrom/django-components/issues/669
+    for conf in apps.get_app_configs():
+        for app_dir in app_settings.APP_DIRS:
+            comps_path = Path(conf.path).joinpath(app_dir)
+            if not comps_path.exists():
+                continue
+            app_component_filepaths = _search_dirs([comps_path], search_glob)
+            for filepath in app_component_filepaths:
+                app_component_module = _filepath_to_python_module(filepath, conf.path, conf.name)
+                entry = ComponentFileEntry(dot_path=app_component_module, filepath=filepath)
+                modules.append(entry)
+
+    return modules
+
+
+def _filepath_to_python_module(
+    file_path: Union[Path, str],
+    root_fs_path: Union[str, Path],
+    root_module_path: Optional[str],
+) -> str:
+    """
+    Derive python import path from the filesystem path.
+
+    Example:
+    - If project root is `/path/to/project`
+    - And file_path is `/path/to/project/app/components/mycomp.py`
+    - Then the path relative to project root is `app/components/mycomp.py`
+    - Which we then turn into python import path `app.components.mycomp`
+    """
+    rel_path = os.path.relpath(file_path, start=root_fs_path)
+    rel_path_without_suffix = str(Path(rel_path).with_suffix(""))
+
+    # NOTE: `Path` normalizes paths to use `/` as separator, while `os.path`
+    # uses `os.path.sep`.
+    sep = os.path.sep if os.path.sep in rel_path_without_suffix else "/"
+    module_name = rel_path_without_suffix.replace(sep, ".")
+
+    # Combine with the base module path
+    full_module_name = f"{root_module_path}.{module_name}" if root_module_path else module_name
+    if full_module_name.endswith(".__init__"):
+        full_module_name = full_module_name[:-9]  # Remove the trailing `.__init__
+
+    return full_module_name
+
+
+def _search_dirs(dirs: List[Path], search_glob: str) -> List[Path]:
+    """
+    Search the directories for the given glob pattern. Glob search results are returned
+    as a flattened list.
+    """
+    matched_files: List[Path] = []
+    for directory in dirs:
+        for path in glob.iglob(str(Path(directory) / search_glob), recursive=True):
+            matched_files.append(Path(path))
+
+    return matched_files

--- a/src/django_components/util/loader.py
+++ b/src/django_components/util/loader.py
@@ -6,8 +6,8 @@ from typing import List, NamedTuple, Optional, Set, Union
 from django.apps import apps
 from django.conf import settings
 
-from django_components.util.logger import logger
 from django_components.app_settings import app_settings
+from django_components.util.logger import logger
 
 
 def get_component_dirs(include_apps: bool = True) -> List[Path]:
@@ -102,6 +102,7 @@ def get_component_dirs(include_apps: bool = True) -> List[Path]:
 
 class ComponentFileEntry(NamedTuple):
     """Result returned by [`get_component_files()`](../api#django_components.get_component_files)."""
+
     dot_path: str
     """The python import path for the module. E.g. `app.components.mycomp`"""
     filepath: Path
@@ -118,7 +119,7 @@ def get_component_files(suffix: Optional[str] = None) -> List[ComponentFileEntry
     Args:
         suffix (Optional[str], optional): The suffix to search for. E.g. `.py`, `.js`, `.css`.\
             Defaults to `None`, which will search for all files.
-    
+
     Returns:
         List[ComponentFileEntry] A list of entries that contain both the filesystem path and \
             the python import path (dot path).

--- a/src/django_components/util/loader.py
+++ b/src/django_components/util/loader.py
@@ -48,7 +48,7 @@ def get_component_dirs(include_apps: bool = True) -> List[Path]:
     # TODO_REMOVE_IN_V1
     is_legacy_paths = (
         # Use value of `STATICFILES_DIRS` ONLY if `COMPONENT.dirs` not set
-        getattr(settings, "COMPONENTS", {}).get("dirs", None) is None
+        not app_settings.DIRS
         and hasattr(settings, "STATICFILES_DIRS")
         and settings.STATICFILES_DIRS
     )

--- a/src/django_components/util/misc.py
+++ b/src/django_components/util/misc.py
@@ -1,10 +1,7 @@
-import glob
 import re
-from pathlib import Path
-from typing import Any, Callable, List, Optional, Sequence, Type, TypeVar, Union
+from typing import Any, Callable, List, Optional, Type, TypeVar
 
 from django.template.defaultfilters import escape
-from django.utils.autoreload import autoreload_started
 
 from django_components.util.nanoid import generate
 
@@ -36,35 +33,12 @@ def is_str_wrapped_in_quotes(s: str) -> bool:
     return s.startswith(('"', "'")) and s[0] == s[-1] and len(s) >= 2
 
 
-# See https://github.com/EmilStenstrom/django-components/issues/586#issue-2472678136
-def watch_files_for_autoreload(watch_list: Sequence[Union[str, Path]]) -> None:
-    def autoreload_hook(sender: Any, *args: Any, **kwargs: Any) -> None:
-        watch = sender.extra_files.add
-        for file in watch_list:
-            watch(Path(file))
-
-    autoreload_started.connect(autoreload_hook)
-
-
 def any_regex_match(string: str, patterns: List[re.Pattern]) -> bool:
     return any(p.search(string) is not None for p in patterns)
 
 
 def no_regex_match(string: str, patterns: List[re.Pattern]) -> bool:
     return all(p.search(string) is None for p in patterns)
-
-
-def search_dirs(dirs: List[Path], search_glob: str) -> List[Path]:
-    """
-    Search the directories for the given glob pattern. Glob search results are returned
-    as a flattened list.
-    """
-    matched_files: List[Path] = []
-    for directory in dirs:
-        for path in glob.iglob(str(Path(directory) / search_glob), recursive=True):
-            matched_files.append(Path(path))
-
-    return matched_files
 
 
 # See https://stackoverflow.com/a/2020083/9788634

--- a/tests/test_autodiscover.py
+++ b/tests/test_autodiscover.py
@@ -1,11 +1,10 @@
-import os
 import sys
-from unittest import TestCase, mock
+from unittest import TestCase
 
 from django.conf import settings
 
 from django_components import AlreadyRegistered, registry
-from django_components.autodiscovery import _filepath_to_python_module, autodiscover, import_libraries
+from django_components.autodiscovery import autodiscover, import_libraries
 
 from .django_test_setup import setup_test_config
 
@@ -116,50 +115,3 @@ class TestImportLibraries(_TestCase):
         self.assertIn("multi_file_component", all_components)
 
         settings.COMPONENTS["libraries"] = []
-
-
-class TestFilepathToPythonModule(_TestCase):
-    def test_prepares_path(self):
-        base_path = str(settings.BASE_DIR)
-
-        the_path = os.path.join(base_path, "tests.py")
-        self.assertEqual(
-            _filepath_to_python_module(the_path, base_path, None),
-            "tests",
-        )
-
-        the_path = os.path.join(base_path, "tests/components/relative_file/relative_file.py")
-        self.assertEqual(
-            _filepath_to_python_module(the_path, base_path, None),
-            "tests.components.relative_file.relative_file",
-        )
-
-    def test_handles_nonlinux_paths(self):
-        base_path = str(settings.BASE_DIR).replace("/", "//")
-
-        with mock.patch("os.path.sep", new="//"):
-            the_path = os.path.join(base_path, "tests.py")
-            self.assertEqual(
-                _filepath_to_python_module(the_path, base_path, None),
-                "tests",
-            )
-
-            the_path = os.path.join(base_path, "tests//components//relative_file//relative_file.py")
-            self.assertEqual(
-                _filepath_to_python_module(the_path, base_path, None),
-                "tests.components.relative_file.relative_file",
-            )
-
-        base_path = str(settings.BASE_DIR).replace("//", "\\")
-        with mock.patch("os.path.sep", new="\\"):
-            the_path = os.path.join(base_path, "tests.py")
-            self.assertEqual(
-                _filepath_to_python_module(the_path, base_path, None),
-                "tests",
-            )
-
-            the_path = os.path.join(base_path, "tests\\components\\relative_file\\relative_file.py")
-            self.assertEqual(
-                _filepath_to_python_module(the_path, base_path, None),
-                "tests.components.relative_file.relative_file",
-            )

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -124,7 +124,7 @@ class StaticFilesFinderTests(SimpleTestCase):
             "static_files_allowed": [
                 ".js",
             ],
-            "forbidden_static_files": [],
+            "static_files_forbidden": [],
         },
         STATICFILES_FINDERS=[
             # Default finders
@@ -153,7 +153,7 @@ class StaticFilesFinderTests(SimpleTestCase):
             "static_files_allowed": [
                 re.compile(r".*"),
             ],
-            "forbidden_static_files": [
+            "static_files_forbidden": [
                 re.compile(r"\.(?:js)$"),
             ],
         },
@@ -185,7 +185,7 @@ class StaticFilesFinderTests(SimpleTestCase):
                 ".js",
                 ".css",
             ],
-            "forbidden_static_files": [
+            "static_files_forbidden": [
                 ".js",
             ],
         },

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
-from django_components.template_loader import get_component_dirs
+from django_components.util.loader import get_component_dirs, get_component_files
 
 from .django_test_setup import setup_test_config
 from .testutils import BaseTestCase
@@ -12,7 +12,7 @@ from .testutils import BaseTestCase
 setup_test_config({"autodiscover": False})
 
 
-class TemplateLoaderTest(BaseTestCase):
+class ComponentDirsTest(BaseTestCase):
     @override_settings(
         BASE_DIR=Path(__file__).parent.resolve(),
     )
@@ -64,7 +64,7 @@ class TemplateLoaderTest(BaseTestCase):
             ("with_not_str_alias", 3),
         ],  # noqa
     )
-    @patch("django_components.template_loader.logger.warning")
+    @patch("django_components.util.loader.logger.warning")
     def test_get_dirs__components_dirs(self, mock_warning: MagicMock):
         mock_warning.reset_mock()
         dirs = sorted(get_component_dirs())
@@ -212,4 +212,78 @@ class TemplateLoaderTest(BaseTestCase):
                 Path(__file__).parent.resolve()
                 / "components",
             ],
+        )
+
+
+class ComponentFilesTest(BaseTestCase):
+    @override_settings(
+        BASE_DIR=Path(__file__).parent.resolve(),
+    )
+    def test_get_files__py(self):
+        files = sorted(get_component_files(".py"))
+
+        dot_paths = [f.dot_path for f in files]
+        file_paths = [str(f.filepath) for f in files]
+
+        self.assertEqual(
+            dot_paths,
+            [
+                'components',
+                'components.multi_file.multi_file',
+                'components.relative_file.relative_file',
+                'components.relative_file_pathobj.relative_file_pathobj',
+                'components.single_file',
+                'components.staticfiles.staticfiles',
+                'components.urls',
+                'django_components.components',
+                'django_components.components.dynamic',
+                'tests.test_app.components.app_lvl_comp.app_lvl_comp',
+            ]
+        )
+
+        self.assertEqual(
+            [
+                file_paths[0].endswith('tests/components/__init__.py'),
+                file_paths[1].endswith('tests/components/multi_file/multi_file.py'),
+                file_paths[2].endswith('tests/components/relative_file/relative_file.py'),
+                file_paths[3].endswith('tests/components/relative_file_pathobj/relative_file_pathobj.py'),
+                file_paths[4].endswith('tests/components/single_file.py'),
+                file_paths[5].endswith('tests/components/staticfiles/staticfiles.py'),
+                file_paths[6].endswith('tests/components/urls.py'),
+                file_paths[7].endswith('django_components/components/__init__.py'),
+                file_paths[8].endswith('django_components/components/dynamic.py'),
+                file_paths[9].endswith('tests/test_app/components/app_lvl_comp/app_lvl_comp.py'),
+            ],
+            [True for _ in range(len(file_paths))]
+        )
+
+    @override_settings(
+        BASE_DIR=Path(__file__).parent.resolve(),
+    )
+    def test_get_files__js(self):
+        files = sorted(get_component_files(".js"))
+
+        dot_paths = [f.dot_path for f in files]
+        file_paths = [str(f.filepath) for f in files]
+
+        print(file_paths)
+
+        self.assertEqual(
+            dot_paths,
+            [
+                'components.relative_file.relative_file',
+                'components.relative_file_pathobj.relative_file_pathobj',
+                'components.staticfiles.staticfiles',
+                'tests.test_app.components.app_lvl_comp.app_lvl_comp',
+            ]
+        )
+
+        self.assertEqual(
+            [
+                file_paths[0].endswith('tests/components/relative_file/relative_file.js'),
+                file_paths[1].endswith('tests/components/relative_file_pathobj/relative_file_pathobj.js'),
+                file_paths[2].endswith('tests/components/staticfiles/staticfiles.js'),
+                file_paths[3].endswith('tests/test_app/components/app_lvl_comp/app_lvl_comp.js'),
+            ],
+            [True for _ in range(len(file_paths))]
         )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,8 +3,8 @@ import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from django.test import override_settings
 from django.conf import settings
+from django.test import override_settings
 
 from django_components.util.loader import _filepath_to_python_module, get_component_dirs, get_component_files
 
@@ -230,33 +230,33 @@ class ComponentFilesTest(BaseTestCase):
         self.assertEqual(
             dot_paths,
             [
-                'components',
-                'components.multi_file.multi_file',
-                'components.relative_file.relative_file',
-                'components.relative_file_pathobj.relative_file_pathobj',
-                'components.single_file',
-                'components.staticfiles.staticfiles',
-                'components.urls',
-                'django_components.components',
-                'django_components.components.dynamic',
-                'tests.test_app.components.app_lvl_comp.app_lvl_comp',
-            ]
+                "components",
+                "components.multi_file.multi_file",
+                "components.relative_file.relative_file",
+                "components.relative_file_pathobj.relative_file_pathobj",
+                "components.single_file",
+                "components.staticfiles.staticfiles",
+                "components.urls",
+                "django_components.components",
+                "django_components.components.dynamic",
+                "tests.test_app.components.app_lvl_comp.app_lvl_comp",
+            ],
         )
 
         self.assertEqual(
             [
-                file_paths[0].endswith('tests/components/__init__.py'),
-                file_paths[1].endswith('tests/components/multi_file/multi_file.py'),
-                file_paths[2].endswith('tests/components/relative_file/relative_file.py'),
-                file_paths[3].endswith('tests/components/relative_file_pathobj/relative_file_pathobj.py'),
-                file_paths[4].endswith('tests/components/single_file.py'),
-                file_paths[5].endswith('tests/components/staticfiles/staticfiles.py'),
-                file_paths[6].endswith('tests/components/urls.py'),
-                file_paths[7].endswith('django_components/components/__init__.py'),
-                file_paths[8].endswith('django_components/components/dynamic.py'),
-                file_paths[9].endswith('tests/test_app/components/app_lvl_comp/app_lvl_comp.py'),
+                file_paths[0].endswith("tests/components/__init__.py"),
+                file_paths[1].endswith("tests/components/multi_file/multi_file.py"),
+                file_paths[2].endswith("tests/components/relative_file/relative_file.py"),
+                file_paths[3].endswith("tests/components/relative_file_pathobj/relative_file_pathobj.py"),
+                file_paths[4].endswith("tests/components/single_file.py"),
+                file_paths[5].endswith("tests/components/staticfiles/staticfiles.py"),
+                file_paths[6].endswith("tests/components/urls.py"),
+                file_paths[7].endswith("django_components/components/__init__.py"),
+                file_paths[8].endswith("django_components/components/dynamic.py"),
+                file_paths[9].endswith("tests/test_app/components/app_lvl_comp/app_lvl_comp.py"),
             ],
-            [True for _ in range(len(file_paths))]
+            [True for _ in range(len(file_paths))],
         )
 
     @override_settings(
@@ -273,21 +273,21 @@ class ComponentFilesTest(BaseTestCase):
         self.assertEqual(
             dot_paths,
             [
-                'components.relative_file.relative_file',
-                'components.relative_file_pathobj.relative_file_pathobj',
-                'components.staticfiles.staticfiles',
-                'tests.test_app.components.app_lvl_comp.app_lvl_comp',
-            ]
+                "components.relative_file.relative_file",
+                "components.relative_file_pathobj.relative_file_pathobj",
+                "components.staticfiles.staticfiles",
+                "tests.test_app.components.app_lvl_comp.app_lvl_comp",
+            ],
         )
 
         self.assertEqual(
             [
-                file_paths[0].endswith('tests/components/relative_file/relative_file.js'),
-                file_paths[1].endswith('tests/components/relative_file_pathobj/relative_file_pathobj.js'),
-                file_paths[2].endswith('tests/components/staticfiles/staticfiles.js'),
-                file_paths[3].endswith('tests/test_app/components/app_lvl_comp/app_lvl_comp.js'),
+                file_paths[0].endswith("tests/components/relative_file/relative_file.js"),
+                file_paths[1].endswith("tests/components/relative_file_pathobj/relative_file_pathobj.js"),
+                file_paths[2].endswith("tests/components/staticfiles/staticfiles.js"),
+                file_paths[3].endswith("tests/test_app/components/app_lvl_comp/app_lvl_comp.js"),
             ],
-            [True for _ in range(len(file_paths))]
+            [True for _ in range(len(file_paths))],
         )
 
 


### PR DESCRIPTION
This MR is a mix of a couple of changes, it grew a bit out of scope, sorry about that.

Initially I wanted to only rename the settings:
- `forbidden_static_files` -> `static_files_forbidden`, so it's aligned with `static_files_allowed`
- `reload_on_template_change` -> `reload_on_file_change`, because using the word "template" suggests that this would apply only to HTML files.

Similarly to the last MR, the old names of the settings are kept, but tagged as deprecated, and would be removed in v1.

Moreover, the reload-on-change feature (`reload_on_template_change`) wasn't working, so I wanted to fix that. But for that I needed to obtain the same list of directories as we use in `autodiscover()`.

Moreover, for django_vue, I also need to access the same list of directories, so I can search them for `.vue` files.

So what this resulted into is that I extracted the logic that was inside `template_loader.py` and `autodiscovery.py`, and moved it to `util/loader.py`. And I've added 2 functions to the public API:
- `get_component_dirs()` - This returns the same directories as used by `autodiscover()`
- `get_component_files(suffix)` - This searches the directories from `get_component_dirs()` for files with a given suffix.