### PR TITLE
fix: apostrophes in tags

### DIFF
--- a/src/django_components/util/tag_parser.py
+++ b/src/django_components/util/tag_parser.py
@@ -71,11 +71,7 @@ def parse_tag_attrs(text: str) -> Tuple[str, List[TagAttr]]:
     # tag_name = take_until([" ", "\t", "\n", "\r", "\f", ">", "/>"])
     def take_until(
         tokens: Sequence[Union[str, Tuple[str, ...]]],
-        ignore: Optional[
-            Sequence[
-                Union[str, Tuple[str, ...]],
-            ]
-        ] = None,
+        ignore: Optional[Sequence[Union[str, Tuple[str, ...]],]] = None,
     ) -> str:
         nonlocal index
         nonlocal text

--- a/src/django_components/util/tag_parser.py
+++ b/src/django_components/util/tag_parser.py
@@ -1,0 +1,202 @@
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple, Union
+
+TAG_WHITESPACE = (" ", "\t", "\n", "\r", "\f")
+
+
+@dataclass
+class TagAttr:
+    key: Optional[str]
+    value: str
+    start_index: int
+    """
+    Start index of the attribute (include both key and value),
+    relative to the start of the owner Tag.
+    """
+    quoted: bool
+    """Whether the value is quoted (either with single or double quotes)"""
+
+
+# Parse the content of a Django template tag like this:
+#
+# ```django
+# {% component "my_comp" key="my val's" key2=val2 %}
+# ```
+#
+# into a tag name and a list of attributes:
+#
+# ```python
+# {
+#     "component": "component",
+# }
+# ```
+def parse_tag_attrs(text: str) -> Tuple[str, List[TagAttr]]:
+    index = 0
+    normalized = ""
+
+    def add_token(token: Union[str, Tuple[str, ...]]) -> None:
+        nonlocal normalized
+        nonlocal index
+
+        text = "".join(token)
+        normalized += text
+        index += len(text)
+
+    def is_next_token(*tokens: Union[str, Tuple[str, ...]]) -> bool:
+        if not tokens:
+            raise ValueError("No tokens provided")
+
+        def is_token_match(token: Union[str, Tuple[str, ...]]) -> bool:
+            if not token:
+                raise ValueError("Empty token")
+
+            for token_index, token_char in enumerate(token):
+                text_char = text[index + token_index] if index + token_index < len(text) else None
+                if text_char is None or text_char != token_char:
+                    return False
+            return True
+
+        for token in tokens:
+            is_match = is_token_match(token)
+            if is_match:
+                return True
+        return False
+
+    def taken_n(n: int) -> str:
+        nonlocal index
+        result = text[index : index + n]
+        add_token(result)
+        return result
+
+    # tag_name = take_until([" ", "\t", "\n", "\r", "\f", ">", "/>"])
+    def take_until(
+        tokens: Sequence[Union[str, Tuple[str, ...]]],
+        ignore: Optional[
+            Sequence[
+                Union[str, Tuple[str, ...]],
+            ]
+        ] = None,
+    ) -> str:
+        nonlocal index
+        nonlocal text
+
+        result = ""
+        while index < len(text):
+            char = text[index]
+
+            ignore_token_match: Optional[Union[str, Tuple[str, ...]]] = None
+            for ignore_token in ignore or []:
+                if is_next_token(ignore_token):
+                    ignore_token_match = ignore_token
+
+            if ignore_token_match:
+                result += "".join(ignore_token_match)
+                add_token(ignore_token_match)
+                continue
+
+            if any(is_next_token(token) for token in tokens):
+                return result
+
+            result += char
+            add_token(char)
+        return result
+
+    # tag_name = take_while([" ", "\t", "\n", "\r", "\f"])
+    def take_while(tokens: Sequence[Union[str, Tuple[str, ...]]]) -> str:
+        nonlocal index
+        nonlocal text
+
+        result = ""
+        while index < len(text):
+            char = text[index]
+
+            if any(is_next_token(token) for token in tokens):
+                result += char
+                add_token(char)
+            else:
+                return result
+
+        return result
+
+    # Parse
+    attrs: List[TagAttr] = []
+    while index < len(text):
+        # Skip whitespace
+        take_while(TAG_WHITESPACE)
+
+        start_index = len(normalized)
+
+        # If token starts with a quote, we assume it's a value without key part.
+        # e.g. `component 'my_comp'`
+        # Otherwise, parse the key.
+        if is_next_token("'", '"', '_("', "_('"):
+            key = None
+        else:
+            key = take_until(["=", *TAG_WHITESPACE])
+
+            # We've reached the end of the text
+            if not key:
+                break
+
+            # Has value
+            if is_next_token("="):
+                add_token("=")
+            else:
+                # Actually was a value without key part
+                attrs.append(
+                    TagAttr(
+                        key=None,
+                        value=key,
+                        start_index=start_index,
+                        quoted=False,
+                    )
+                )
+                continue
+
+        # Parse the value
+        #
+        # E.g. `height="20"`
+        # NOTE: We don't need to parse the attributes fully. We just need to account
+        # for the quotes.
+        if is_next_token("'", '"', '_("', "_('"):
+            # NOTE: Strings may be wrapped in `_()` to allow for translation.
+            # See https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#string-literals-passed-to-tags-and-filters
+            if is_next_token("_("):
+                taken_n(2)  # _(
+                is_translation = True
+            else:
+                is_translation = False
+
+            # NOTE: We assume no space between the translation syntax and the quote.
+            quote_char = taken_n(1)  # " or '
+
+            # NOTE: Handle escaped quotes like \" or \', and continue until we reach the closing quote.
+            value = take_until([quote_char], ignore=["\\" + quote_char])
+            # Handle the case when there is a trailing quote, e.g. when a text value is not closed.
+            # `{% component 'my_comp' text="organis %}`
+
+            if is_next_token(quote_char):
+                add_token(quote_char)
+                if is_translation:
+                    value += taken_n(1)  # )
+                quoted = True
+            else:
+                quoted = False
+                value = quote_char + value
+                if is_translation:
+                    value = "_(" + value
+        # E.g. `height=20`
+        else:
+            value = take_until(TAG_WHITESPACE)
+            quoted = False
+
+        attrs.append(
+            TagAttr(
+                key=key,
+                value=value,
+                start_index=start_index,
+                quoted=quoted,
+            )
+        )
+
+    return normalized, attrs

--- a/src/django_components/util/tag_parser.py
+++ b/src/django_components/util/tag_parser.py
@@ -64,7 +64,7 @@ def parse_tag_attrs(text: str) -> Tuple[str, List[TagAttr]]:
 
     def taken_n(n: int) -> str:
         nonlocal index
-        result = text[index : index + n]
+        result = text[index : index + n]  # noqa: E203
         add_token(result)
         return result
 
@@ -156,7 +156,7 @@ def parse_tag_attrs(text: str) -> Tuple[str, List[TagAttr]]:
         # for the quotes.
         if is_next_token("'", '"', '_("', "_('"):
             # NOTE: Strings may be wrapped in `_()` to allow for translation.
-            # See https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#string-literals-passed-to-tags-and-filters
+            # See https://docs.djangoproject.com/en/5.1/topics/i18n/translation/#string-literals-passed-to-tags-and-filters  # noqa: E501
             if is_next_token("_("):
                 taken_n(2)  # _(
                 is_translation = True

--- a/tests/test_tag_parser.py
+++ b/tests/test_tag_parser.py
@@ -9,64 +9,86 @@ setup_test_config({"autodiscover": False})
 class TagParserTests(BaseTestCase):
     def test_tag_parser(self):
         _, attrs = parse_tag_attrs("component 'my_comp' key=val key2='val2 two' ")
-        self.assertEqual(attrs, [
-            TagAttr(key=None, value='component', start_index=0, quoted=False),
-            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
-            TagAttr(key='key', value='val', start_index=20, quoted=False),
-            TagAttr(key='key2', value='val2 two', start_index=28, quoted=True),
-        ])
+        self.assertEqual(
+            attrs,
+            [
+                TagAttr(key=None, value="component", start_index=0, quoted=False),
+                TagAttr(key=None, value="my_comp", start_index=10, quoted=True),
+                TagAttr(key="key", value="val", start_index=20, quoted=False),
+                TagAttr(key="key2", value="val2 two", start_index=28, quoted=True),
+            ],
+        )
 
     def test_tag_parser_nested_quotes(self):
         _, attrs = parse_tag_attrs("component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" ")
-        self.assertEqual(attrs, [
-            TagAttr(key=None, value='component', start_index=0, quoted=False),
-            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
-            TagAttr(key='key', value='val', start_index=20, quoted=False),
-            TagAttr(key='key2', value='val2 "two"', start_index=28, quoted=True),
-            TagAttr(key='text', value="organisation's", start_index=46, quoted=True)
-        ])
+        self.assertEqual(
+            attrs,
+            [
+                TagAttr(key=None, value="component", start_index=0, quoted=False),
+                TagAttr(key=None, value="my_comp", start_index=10, quoted=True),
+                TagAttr(key="key", value="val", start_index=20, quoted=False),
+                TagAttr(key="key2", value='val2 "two"', start_index=28, quoted=True),
+                TagAttr(key="text", value="organisation's", start_index=46, quoted=True),
+            ],
+        )
 
     def test_tag_parser_trailing_quote_single(self):
         _, attrs = parse_tag_attrs("component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" 'abc")
 
-        self.assertEqual(attrs, [
-            TagAttr(key=None, value='component', start_index=0, quoted=False),
-            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
-            TagAttr(key='key', value='val', start_index=20, quoted=False),
-            TagAttr(key='key2', value='val2 "two"', start_index=28, quoted=True),
-            TagAttr(key='text', value="organisation's", start_index=46, quoted=True),
-            TagAttr(key=None, value="'abc", start_index=68, quoted=False),
-        ])
+        self.assertEqual(
+            attrs,
+            [
+                TagAttr(key=None, value="component", start_index=0, quoted=False),
+                TagAttr(key=None, value="my_comp", start_index=10, quoted=True),
+                TagAttr(key="key", value="val", start_index=20, quoted=False),
+                TagAttr(key="key2", value='val2 "two"', start_index=28, quoted=True),
+                TagAttr(key="text", value="organisation's", start_index=46, quoted=True),
+                TagAttr(key=None, value="'abc", start_index=68, quoted=False),
+            ],
+        )
 
     def test_tag_parser_trailing_quote_double(self):
         _, attrs = parse_tag_attrs('component "my_comp" key=val key2="val2 \'two\'" text=\'organisation"s\' "abc')
-        self.assertEqual(attrs, [
-            TagAttr(key=None, value='component', start_index=0, quoted=False),
-            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
-            TagAttr(key='key', value='val', start_index=20, quoted=False),
-            TagAttr(key='key2', value="val2 'two'", start_index=28, quoted=True),
-            TagAttr(key='text', value='organisation"s', start_index=46, quoted=True),
-            TagAttr(key=None, value='"abc', start_index=68, quoted=False),
-        ])
+        self.assertEqual(
+            attrs,
+            [
+                TagAttr(key=None, value="component", start_index=0, quoted=False),
+                TagAttr(key=None, value="my_comp", start_index=10, quoted=True),
+                TagAttr(key="key", value="val", start_index=20, quoted=False),
+                TagAttr(key="key2", value="val2 'two'", start_index=28, quoted=True),
+                TagAttr(key="text", value='organisation"s', start_index=46, quoted=True),
+                TagAttr(key=None, value='"abc', start_index=68, quoted=False),
+            ],
+        )
 
     def test_tag_parser_trailing_quote_as_value_single(self):
-        _, attrs = parse_tag_attrs("component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" value='abc")
-        self.assertEqual(attrs, [
-            TagAttr(key=None, value='component', start_index=0, quoted=False),
-            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
-            TagAttr(key='key', value='val', start_index=20, quoted=False),
-            TagAttr(key='key2', value='val2 "two"', start_index=28, quoted=True),
-            TagAttr(key='text', value="organisation's", start_index=46, quoted=True),
-            TagAttr(key="value", value="'abc", start_index=68, quoted=False),
-        ])
+        _, attrs = parse_tag_attrs(
+            "component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" value='abc"
+        )
+        self.assertEqual(
+            attrs,
+            [
+                TagAttr(key=None, value="component", start_index=0, quoted=False),
+                TagAttr(key=None, value="my_comp", start_index=10, quoted=True),
+                TagAttr(key="key", value="val", start_index=20, quoted=False),
+                TagAttr(key="key2", value='val2 "two"', start_index=28, quoted=True),
+                TagAttr(key="text", value="organisation's", start_index=46, quoted=True),
+                TagAttr(key="value", value="'abc", start_index=68, quoted=False),
+            ],
+        )
 
     def test_tag_parser_trailing_quote_as_value_double(self):
-        _, attrs = parse_tag_attrs('component "my_comp" key=val key2="val2 \'two\'" text=\'organisation"s\' value="abc')
-        self.assertEqual(attrs, [
-            TagAttr(key=None, value='component', start_index=0, quoted=False),
-            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
-            TagAttr(key='key', value='val', start_index=20, quoted=False),
-            TagAttr(key='key2', value="val2 'two'", start_index=28, quoted=True),
-            TagAttr(key='text', value='organisation"s', start_index=46, quoted=True),
-            TagAttr(key='value', value='"abc', start_index=68, quoted=False),
-        ])
+        _, attrs = parse_tag_attrs(
+            'component "my_comp" key=val key2="val2 \'two\'" text=\'organisation"s\' value="abc'
+        )
+        self.assertEqual(
+            attrs,
+            [
+                TagAttr(key=None, value="component", start_index=0, quoted=False),
+                TagAttr(key=None, value="my_comp", start_index=10, quoted=True),
+                TagAttr(key="key", value="val", start_index=20, quoted=False),
+                TagAttr(key="key2", value="val2 'two'", start_index=28, quoted=True),
+                TagAttr(key="text", value='organisation"s', start_index=46, quoted=True),
+                TagAttr(key="value", value='"abc', start_index=68, quoted=False),
+            ],
+        )

--- a/tests/test_tag_parser.py
+++ b/tests/test_tag_parser.py
@@ -1,0 +1,72 @@
+from django_components.util.tag_parser import TagAttr, parse_tag_attrs
+
+from .django_test_setup import setup_test_config
+from .testutils import BaseTestCase
+
+setup_test_config({"autodiscover": False})
+
+
+class TagParserTests(BaseTestCase):
+    def test_tag_parser(self):
+        _, attrs = parse_tag_attrs("component 'my_comp' key=val key2='val2 two' ")
+        self.assertEqual(attrs, [
+            TagAttr(key=None, value='component', start_index=0, quoted=False),
+            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
+            TagAttr(key='key', value='val', start_index=20, quoted=False),
+            TagAttr(key='key2', value='val2 two', start_index=28, quoted=True),
+        ])
+
+    def test_tag_parser_nested_quotes(self):
+        _, attrs = parse_tag_attrs("component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" ")
+        self.assertEqual(attrs, [
+            TagAttr(key=None, value='component', start_index=0, quoted=False),
+            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
+            TagAttr(key='key', value='val', start_index=20, quoted=False),
+            TagAttr(key='key2', value='val2 "two"', start_index=28, quoted=True),
+            TagAttr(key='text', value="organisation's", start_index=46, quoted=True)
+        ])
+
+    def test_tag_parser_trailing_quote_single(self):
+        _, attrs = parse_tag_attrs("component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" 'abc")
+
+        self.assertEqual(attrs, [
+            TagAttr(key=None, value='component', start_index=0, quoted=False),
+            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
+            TagAttr(key='key', value='val', start_index=20, quoted=False),
+            TagAttr(key='key2', value='val2 "two"', start_index=28, quoted=True),
+            TagAttr(key='text', value="organisation's", start_index=46, quoted=True),
+            TagAttr(key=None, value="'abc", start_index=68, quoted=False),
+        ])
+
+    def test_tag_parser_trailing_quote_double(self):
+        _, attrs = parse_tag_attrs('component "my_comp" key=val key2="val2 \'two\'" text=\'organisation"s\' "abc')
+        self.assertEqual(attrs, [
+            TagAttr(key=None, value='component', start_index=0, quoted=False),
+            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
+            TagAttr(key='key', value='val', start_index=20, quoted=False),
+            TagAttr(key='key2', value="val2 'two'", start_index=28, quoted=True),
+            TagAttr(key='text', value='organisation"s', start_index=46, quoted=True),
+            TagAttr(key=None, value='"abc', start_index=68, quoted=False),
+        ])
+
+    def test_tag_parser_trailing_quote_as_value_single(self):
+        _, attrs = parse_tag_attrs("component 'my_comp' key=val key2='val2 \"two\"' text=\"organisation's\" value='abc")
+        self.assertEqual(attrs, [
+            TagAttr(key=None, value='component', start_index=0, quoted=False),
+            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
+            TagAttr(key='key', value='val', start_index=20, quoted=False),
+            TagAttr(key='key2', value='val2 "two"', start_index=28, quoted=True),
+            TagAttr(key='text', value="organisation's", start_index=46, quoted=True),
+            TagAttr(key="value", value="'abc", start_index=68, quoted=False),
+        ])
+
+    def test_tag_parser_trailing_quote_as_value_double(self):
+        _, attrs = parse_tag_attrs('component "my_comp" key=val key2="val2 \'two\'" text=\'organisation"s\' value="abc')
+        self.assertEqual(attrs, [
+            TagAttr(key=None, value='component', start_index=0, quoted=False),
+            TagAttr(key=None, value='my_comp', start_index=10, quoted=True),
+            TagAttr(key='key', value='val', start_index=20, quoted=False),
+            TagAttr(key='key2', value="val2 'two'", start_index=28, quoted=True),
+            TagAttr(key='text', value='organisation"s', start_index=46, quoted=True),
+            TagAttr(key='value', value='"abc', start_index=68, quoted=False),
+        ])

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -516,26 +516,83 @@ class MultilineTagsTests(BaseTestCase):
 
 
 class NestedTagsTests(BaseTestCase):
+    class SimpleComponent(Component):
+        template: types.django_html = """
+            Variable: <strong>{{ var }}</strong>
+        """
+
+        def get_context_data(self, var):
+            return {
+                "var": var,
+            }
+
     # See https://github.com/EmilStenstrom/django-components/discussions/671
     @parametrize_context_behavior(["django", "isolated"])
     def test_nested_tags(self):
-        @register("test_component")
-        class SimpleComponent(Component):
-            template: types.django_html = """
-                Variable: <strong>{{ var }}</strong>
-            """
-
-            def get_context_data(self, var):
-                return {
-                    "var": var,
-                }
+        registry.register("test", self.SimpleComponent)
 
         template: types.django_html = """
             {% load component_tags %}
-            {% component "test_component" var="{% lorem 1 w %}" %}{% endcomponent %}
+            {% component "test" var="{% lorem 1 w %}" %}{% endcomponent %}
         """
         rendered = Template(template).render(Context())
         expected = """
             Variable: <strong>lorem</strong>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_nested_quote_single(self):
+        registry.register("test", self.SimpleComponent)
+
+        template: types.django_html = """
+            {% load component_tags %}
+            {% component "test" var=_("organisation's") %} {% endcomponent %}
+        """
+        rendered = Template(template).render(Context())
+        expected = """
+            Variable: <strong>organisation's</strong>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_nested_quote_single_self_closing(self):
+        registry.register("test", self.SimpleComponent)
+
+        template: types.django_html = """
+            {% load component_tags %}
+            {% component "test" var=_("organisation's") / %}
+        """
+        rendered = Template(template).render(Context())
+        expected = """
+            Variable: <strong>organisation's</strong>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_nested_quote_double(self):
+        registry.register("test", self.SimpleComponent)
+
+        template: types.django_html = """
+            {% load component_tags %}
+            {% component "test" var=_('organisation"s') %} {% endcomponent %}
+        """
+        rendered = Template(template).render(Context())
+        expected = """
+            Variable: <strong>organisation"s</strong>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    @parametrize_context_behavior(["django", "isolated"])
+    def test_nested_quote_double_self_closing(self):
+        registry.register("test", self.SimpleComponent)
+
+        template: types.django_html = """
+            {% load component_tags %}
+            {% component "test" var=_('organisation"s') / %}
+        """
+        rendered = Template(template).render(Context())
+        expected = """
+            Variable: <strong>organisation"s</strong>
         """
         self.assertHTMLEqual(rendered, expected)


### PR DESCRIPTION
## Background

To support the use of Django template tags inside component inputs, e.g.

```django
{% component
    display_name="{{ first_name }} {{ last_name }}"
    description="{% lorem w 3 %}"
/ %}
```

We have to fix Django's tokenization, because Django simply cuts up the template based on the first found `{% ... %}` pairs. So, in the example above, even though the `{% lorem w 3 %}` is wrapped by quotes, Django wrongly interprets the `{% component %}` tag to be:

```django
{% component
    display_name="{{ first_name }} {{ last_name }}"
    description="{% lorem w 3 %}"
```

## Problem

When Django cuts up a tag incorrectly like above, we can identify it because there's a missing closing quote (`"`).

But the fix I implemented previously is too simplistic, because it just checks if there's an even or odd number of quotes in the tag.

But in https://github.com/EmilStenstrom/django-components/issues/752, we got an example where there's a apostrophe in one of the strings passed to the component, which throws off the quote-counting. With quote-counting, we cannot distinguish whether an extra quote is part of a string or not.

## Solution

So instead here I implemented a proper solution - a low-level parser that processes the tag character-by-character. Using this parser we can distinguish and ignore extra apostrophes that are part of strings. And we also get to know if there is or is not an unclosed quote at the end.

- NOTE: While parsing the content character-by-character felt as an overkill at first. But I don't know how else it could be approached. And, yesterday, I found that I also need this parser for the plugin feature - to allow plugins to pre-process component inputs. So IMO the parser is justified. 

- NOTE 2: This may still leave some obscure edge cases. But to prevent them, we'd have to do the tokenization of the whole template ourselves. So this is good enough for now.

Fixes https://github.com/EmilStenstrom/django-components/issues/752