### PR TITLE
fix: do NOT render component tags when parsing {% component %} body for fills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1311,7 +1311,7 @@ tags:
 {% endcomponent %}
 ```
 
-You can also use `{% for %}`, `{% with %}`, or other tags (even `{% include %}`)
+You can also use `{% for %}`, `{% with %}`, or other non-component tags (even `{% include %}`)
 to construct the `{% fill %}` tags, **as long as these other tags do not leave any text behind!**
 
 ```django

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -896,7 +896,7 @@ class ComponentNode(BaseNode):
         trace_msg("RENDR", "COMP", self.name, self.node_id)
 
         # Do not render nested `{% component %}` tags in other `{% component %}` tags
-        # at the stage when we determining if the latter has named fills or not.
+        # at the stage when we are determining if the latter has named fills or not.
         if _is_extracting_fill(context):
             return ""
 

--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -57,6 +57,7 @@ from django_components.slots import (
     SlotName,
     SlotRef,
     SlotResult,
+    _is_extracting_fill,
     _nodelist_to_slot_render_func,
     resolve_fills,
 )
@@ -893,6 +894,11 @@ class ComponentNode(BaseNode):
 
     def render(self, context: Context) -> str:
         trace_msg("RENDR", "COMP", self.name, self.node_id)
+
+        # Do not render nested `{% component %}` tags in other `{% component %}` tags
+        # at the stage when we determining if the latter has named fills or not.
+        if _is_extracting_fill(context):
+            return ""
 
         component_cls: Type[Component] = self.registry.get(self.name)
 

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -399,7 +399,7 @@ class FillNode(BaseNode):
         self.trace_id = trace_id
 
     def render(self, context: Context) -> str:
-        if self._is_extracting_fill(context):
+        if _is_extracting_fill(context):
             self._extract_fill(context)
             return ""
 
@@ -458,9 +458,6 @@ class FillNode(BaseNode):
             raise RuntimeError(f"Fill tag kwarg '{key}' does not resolve to a valid Python identifier, got '{value}'")
 
         return value
-
-    def _is_extracting_fill(self, context: Context) -> bool:
-        return context.get(FILL_GEN_CONTEXT_KEY, None) is not None
 
     def _extract_fill(self, context: Context) -> None:
         # `FILL_GEN_CONTEXT_KEY` is only ever set when we are rendering content between the
@@ -775,3 +772,7 @@ def _nodelist_to_slot_render_func(
         return rendered
 
     return Slot(content_func=cast(SlotFunc, render_func))
+
+
+def _is_extracting_fill(context: Context) -> bool:
+    return context.get(FILL_GEN_CONTEXT_KEY, None) is not None

--- a/src/docs/concepts/fundamentals/slots.md
+++ b/src/docs/concepts/fundamentals/slots.md
@@ -77,7 +77,7 @@ tags:
 {% endcomponent %}
 ```
 
-You can also use `{% for %}`, `{% with %}`, or other tags (even `{% include %}`)
+You can also use `{% for %}`, `{% with %}`, or other non-component tags (even `{% include %}`)
 to construct the `{% fill %}` tags, **as long as these other tags do not leave any text behind!**
 
 ```django

--- a/tests/test_templatetags_provide.py
+++ b/tests/test_templatetags_provide.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 from django.template import Context, Template, TemplateSyntaxError
 
 from django_components import Component, register, types


### PR DESCRIPTION
Small bug I came across when there is a component nested in another component, whereas the inner one uses `inject()` to use data provided by the outer component.

E.g.

```django
{% component "data_provider" %}
  {%  component "data_user" / %}
{% endcomponent %}
```

This errored, because we tried to render `data_user` component as part of searching for `{% fill %}` tags. But at that point the `data_provider` has not yet provided the data.

So the solution is NOT to render the `{% component %}` tags at that stage.