### PR TITLE
fix: allow components to accept default fill even if no default slot was encountered during rendering

### DIFF
--- a/src/django_components/component.py
+++ b/src/django_components/component.py
@@ -716,10 +716,6 @@ class Component(
                 # Get the component's HTML
                 html_content = template.render(context)
 
-                # After we've rendered the contents, we now know what slots were there,
-                # and thus we can validate that.
-                component_slot_ctx.post_render_validation()
-
                 # Allow to optionally override/modify the rendered content
                 new_output = self.on_render_after(context, template, html_content)
                 html_content = new_output if new_output is not None else html_content


### PR DESCRIPTION
Another bug I encountered while trying to update to v0.110.

When I had a following template:

```django
{% if component_vars.is_filled.activator %}
  <div>
    {% slot "activator" default / %}
  </div>
{% endif %}
```

And I used the component WITHOUT the implicit / default fill:

```django
{% component "Menu" /  %}
```

Then I was getting error

```
Component 'Menu' passed default fill content (i.e. without explicit 'name' kwarg), even though none of its slots is marked as 'default'.
```

While this error made sense when slots were defined statically, it doesn't make sense anymore. Because as you can see above in the template, the default slot still IS defined in the template. But it's just that it was not rendered, because the `{% if %}` branch didn't run.

So I removed the error.