### PR TITLE
fix: do not render slot tag when extracting fill tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Release notes
 
+## v0.114
+
+#### Fix
+
+- Prevent rendering Slot tags during fill discovery stage to fix a case when a component inside a slot
+  fill tried to access provided data too early.
+
+## v0.113
+
+#### Fix
+
+- Ensure consistent order of scripts in `Component.Media.js`
+
+## v0.112
+
+#### Fix
+
+- Allow components to accept default fill even if no default slot was encountered during rendering
+
+## v0.111
+
+#### Fix
+
+- Prevent rendering Component tags during fill discovery stage to fix a case when a component inside the default slot
+  tried to access provided data too early.
+
 ## 🚨📢 v0.110
 
 ### General

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -203,6 +203,12 @@ class SlotNode(BaseNode):
     def render(self, context: Context) -> SafeString:
         trace_msg("RENDR", "SLOT", self.trace_id, self.node_id)
 
+        # Do not render `{% slot %}` tags within the `{% component %} .. {% endcomponent %}` tags
+        # at the fill discovery stage (when we render the component's body to determine if the body
+        # is a default slot, or contains named slots).
+        if _is_extracting_fill(context):
+            return ""
+
         if _COMPONENT_SLOT_CTX_CONTEXT_KEY not in context or not context[_COMPONENT_SLOT_CTX_CONTEXT_KEY]:
             raise TemplateSyntaxError(
                 "Encountered a SlotNode outside of a ComponentNode context. "

--- a/tests/test_templatetags_component.py
+++ b/tests/test_templatetags_component.py
@@ -483,7 +483,7 @@ class DynamicComponentTemplateTagTest(BaseTestCase):
         """
 
         template = Template(simple_tag_template)
-        with self.assertRaisesMessage(TypeError, "got an unexpected keyword argument \\'invalid_variable\\'"):
+        with self.assertRaisesMessage(TypeError, "got an unexpected keyword argument 'invalid_variable'"):
             template.render(Context({}))
 
 


### PR DESCRIPTION
One more bug found. This bug is practically the same as the one in https://github.com/EmilStenstrom/django-components/pull/778/files, where I had to add following snippet to `ComponentNode`:

```py
if _is_extracting_fill(context):
    return ""
```

Except this time this snippet is needed for `SlotNode`.

Beside that, I also updated the error message when an error occurs while rendering a component. Now it shows the component path like so:

```
KeyError: "An error occured while rendering components ProjectPage > ProjectLayoutTabbed >
Layout > RenderContextProvider > Base > TabItem:
Component 'TabItem' tried to inject a variable '_tab' before it was provided."
```