### PR TITLE
refactor: re-add top-level docs/README.md to re-add missing index.html

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -1,0 +1,6 @@
+---
+title: Welcome to Django Components
+weight: 1
+---
+<!-- NOTE: This README.md page is required, because it generates the top-level `index.html` -->
+--8<-- "src/docs/overview/welcome.md:4"


### PR DESCRIPTION
I wasn't aware of this, but when with mkdocs, the `README.md` at the root of the docs directory will be converted to top-level `index.html` file.

Currently, you can see that the updated docs have been published under the `dev` tag:

https://emilstenstrom.github.io/django-components/dev/overview/welcome/

But when you try to go to the docs via the version dropdown, it redirects you to the root:

https://emilstenstrom.github.io/django-components/dev/

Which returns 404, because it's missing the `index.html` file.

So this MR adds the missing file.