### PR TITLE
refactor: configure top-level redirect for docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,8 @@ plugins:
       version_selector: true
   - redirects:
       redirect_maps:
+        # 'old.md': 'new.md'
+        'README.md': 'overview/welcome.md'
   - minify:
       minify_html: true
   - mkdocstrings:
@@ -192,3 +194,4 @@ plugins:
             extensions:
             - docs/scripts/extensions.py:RuntimeBasesExtension
             - docs/scripts/extensions.py:SourceCodeExtension
+            # - docs/scripts/extensions.py:ComponentSyntaxesExtension


### PR DESCRIPTION
This PR address [this comment](https://github.com/EmilStenstrom/django-components/pull/803#pullrequestreview-2479761726) about the homepage and "/overview/welcome" pages looking slightly different.

So this configures the docs redirects so that when user goes to root page, they get redirected to "/overview/welcome"