### PR TITLE
refactor: in `components ext run`, display only those extensions that actually have subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 
 - Fix bug when error formatting failed when error value was not a string.
 
+#### Refactor
+
+- `components ext run` CLI command now allows to call only those extensions that actually have subcommands.
+
 ## v0.140.1
 
 #### Fix

--- a/src/django_components/commands/ext_run.py
+++ b/src/django_components/commands/ext_run.py
@@ -19,6 +19,9 @@ from django_components.util.command import ComponentCommand
 def _gen_subcommands() -> List[Type[ComponentCommand]]:
     commands: List[Type[ComponentCommand]] = []
     for extension in extensions.extensions:
+        if not extension.commands:
+            continue
+
         ExtCommand = type(
             "ExtRunSubcommand_" + extension.name,
             (ComponentCommand,),

--- a/tests/test_command_ext.py
+++ b/tests/test_command_ext.py
@@ -206,21 +206,16 @@ class TestExtensionsRunCommand:
             output
             == dedent(
                 f"""
-                usage: components ext run [-h] {{cache,defaults,view,debug_highlight,empty,dummy}} ...
+                usage: components ext run [-h] {{dummy}} ...
 
                 Run a command added by an extension.
 
                 {OPTIONS_TITLE}:
-                  -h, --help            show this help message and exit
+                  -h, --help  show this help message and exit
 
                 subcommands:
-                  {{cache,defaults,view,debug_highlight,empty,dummy}}
-                    cache               Run commands added by the 'cache' extension.
-                    defaults            Run commands added by the 'defaults' extension.
-                    view                Run commands added by the 'view' extension.
-                    debug_highlight     Run commands added by the 'debug_highlight' extension.
-                    empty               Run commands added by the 'empty' extension.
-                    dummy               Run commands added by the 'dummy' extension.
+                  {{dummy}}
+                    dummy     Run commands added by the 'dummy' extension.
                 """
             ).lstrip()
         )
@@ -231,19 +226,23 @@ class TestExtensionsRunCommand:
     def test_run_command_ext_empty(self):
         out = StringIO()
         with patch("sys.stdout", new=out):
-            call_command("components", "ext", "run", "empty")
+            call_command("components", "ext", "run", "dummy")
         output = out.getvalue()
 
         assert (
             output
             == dedent(
                 f"""
-                usage: components ext run empty [-h]
+                usage: components ext run dummy [-h] {{dummy_cmd}} ...
 
-                Run commands added by the 'empty' extension.
+                Run commands added by the 'dummy' extension.
 
                 {OPTIONS_TITLE}:
-                  -h, --help  show this help message and exit
+                  -h, --help   show this help message and exit
+
+                subcommands:
+                  {{dummy_cmd}}
+                    dummy_cmd  Dummy command description.
                 """
             ).lstrip()
         )


### PR DESCRIPTION
Another small cleanup. The `components ext run` CLI command now displays only those extensions that actually define any subcommands. [See example here](https://github.com/django-components/django-components/pull/1251/files#diff-acd1edd77ed6a5df30cf62e778556047d3a27459db2aa1fac3d6c3b50c29fbe2R209).