### PR TITLE
chore: remove live demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@ to see the latest features and fixes.
 
 One of our goals with `django-components` is to make it easy to share components between projects. If you have a set of components that you think would be useful to others, please open a pull request to add them to the list below.
 
-- [django-htmx-components](https://github.com/iwanalabs/django-htmx-components): A set of components for use with [htmx](https://htmx.org/). Try out the [live demo](https://dhc.iwanalabs.com/).
+- [django-htmx-components](https://github.com/iwanalabs/django-htmx-components): A set of components for use with [htmx](https://htmx.org/).
 
 - [djc-heroicons](https://pypi.org/project/djc-heroicons/): A component that renders icons from [Heroicons.com](https://heroicons.com/).
 

--- a/docs/overview/community.md
+++ b/docs/overview/community.md
@@ -10,6 +10,6 @@ One of our goals with `django-components` is to make it easy to share components
 ([see how to package components](../concepts/advanced/authoring_component_libraries.md)).
 If you have a set of components that you think would be useful to others, please open a pull request to add them to the list below.
 
-- [django-htmx-components](https://github.com/iwanalabs/django-htmx-components): A set of components for use with [htmx](https://htmx.org/). Try out the [live demo](https://dhc.iwanalabs.com/).
+- [django-htmx-components](https://github.com/iwanalabs/django-htmx-components): A set of components for use with [htmx](https://htmx.org/).
 
 - [djc-heroicons](https://pypi.org/project/djc-heroicons/): A component that renders icons from [Heroicons.com](https://heroicons.com/).


### PR DESCRIPTION
Hi Juro and Emil,

Long time no see! 😁

I've seen all the exciting changes you've made to the library. I'm mostly using React/Next.js these days, so I'm not sure I'll get a chance to try them out.

I'm decommissioning the server I used to host the [htmx components](https://dhc.iwanalabs.com/), so I wanted to remove the link from the README before I do. I didn't want you to discover a broken link in the README later on.

Honestly, I also think the components and patterns I built are probably outdated. I'm not sure how helpful they are anymore, but I've left the link for now. Let me know if you'd rather I remove that as well!

Good luck with everything. It was great collaborating with you!