### PR TITLE
Add Google site verification meta tag support in MkDocs

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,12 @@
+{#
+  Theme override: inject Google site verification meta tag.
+  Uses documented extrahead block from Material for MkDocs.
+  If token changes, update in mkdocs.yml under extra.google_site_verification.
+#}
+{% extends "base.html" %}
+{% block extrahead %}
+  {{ super() }}
+  {% if config.extra.google_site_verification %}
+    <meta name="google-site-verification" content="{{ config.extra.google_site_verification }}" />
+  {% endif %}
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ extra:
       link: https://github.com/django-components/django-components
     - icon: fontawesome/brands/python
       link: https://pypi.org/project/django-components/
+  google_site_verification: vQA3d50F2ByQxG0eB6b0YoPnYW9gZo8xnd6HKhCyuys
 
 markdown_extensions:
   abbr: {}


### PR DESCRIPTION
Introduce support for Google site verification by adding a meta tag in the MkDocs configuration. Update the `mkdocs.yml` to include the verification token.

Relevant issue: https://github.com/django-components/django-components/issues/1355