### PR TITLE
fix: fix link to Adding slot page in getting started doc.

### DIFF
--- a/docs/getting_started/adding_slots.md
+++ b/docs/getting_started/adding_slots.md
@@ -292,5 +292,4 @@ each time:
 
 ---
 
-So far we've rendered components using template tag. [Next, let’s explore other ways to render components ➡️]
-(./rendering_components.md)
+So far we've rendered components using template tag. [Next, let’s explore other ways to render components ➡️](./rendering_components.md)


### PR DESCRIPTION
It seems that the problem is caused by a line break.

<img width="732" height="123" alt="Screenshot 2025-09-12 at 9 24 02 AM" src="https://github.com/user-attachments/assets/36f2d6fd-1c4d-4a8f-a93e-83bc11c1f729" />
