### PR TITLE
bug: Test showing bug with components in inclusion_tag

### DIFF
--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -28,6 +28,17 @@ ProvideNode.register(register)
 SlotNode.register(register)
 
 
+@register.inclusion_tag('component_inside_include_sub.html')
+def inclusion_tag():
+    return {}
+
+
+@register.inclusion_tag('component_inside_include_sub.html')
+def inclusion_tag_working():
+    # DJC_DEPS_STRATEGY = ignore fixes the expected behavior.
+    return {"DJC_DEPS_STRATEGY": 'ignore'}
+
+
 # For an intuitive use via Python imports, the tags are aliased to the function name.
 # E.g. so if the tag name is `slot`, one can also do:
 # `from django_components.templatetags.component_tags import slot`

--- a/tests/test_dependency_rendering.py
+++ b/tests/test_dependency_rendering.py
@@ -631,3 +631,69 @@ class TestDependencyRendering:
             <div data-djc-id-ca1bc44>Another</div>
             """,
         )
+
+    def test_dependencies_with_component_in_inclusion_tag(self):
+        registry.register(name="test_component", component=OtherComponent)
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
+            {% inclusion_tag %}
+        """
+        template = Template(template_str)
+        rendered: str = template.render(Context({}))
+
+        # Dependency manager script
+        assertInHTML('<script src="django_components/django_components.min.js"></script>', rendered, count=1)
+        assertInHTML(
+            """
+            <script src="xyz1.js"></script>
+            """,
+            rendered,
+            count=1,
+        )
+        assertInHTML(
+            """
+            <link href="xyz1.css" media="all" rel="stylesheet">
+            """,
+            rendered,
+            count=1,
+        )
+
+        assert rendered.count("<script") == 4  # manager + loader + 2 OtherComponent
+        assert rendered.count("<link") == 1  # 1 OtherComponent
+        assert rendered.count("<style") == 1  # 1 Style
+
+    def test_dependencies_with_component_in_inclusion_tag_working(self):
+        registry.register(name="test_component", component=OtherComponent)
+
+        template_str: types.django_html = """
+            {% load component_tags %}
+            {% component_js_dependencies %}
+            {% component_css_dependencies %}
+            {% inclusion_tag_working %}
+        """
+        template = Template(template_str)
+        rendered: str = template.render(Context({}))
+
+        # Dependency manager script
+        assertInHTML('<script src="django_components/django_components.min.js"></script>', rendered, count=1)
+        assertInHTML(
+            """
+            <script src="xyz1.js"></script>
+            """,
+            rendered,
+            count=1,
+        )
+        assertInHTML(
+            """
+            <link href="xyz1.css" media="all" rel="stylesheet">
+            """,
+            rendered,
+            count=1,
+        )
+
+        assert rendered.count("<script") == 4  # manager + loader + 2 OtherComponent
+        assert rendered.count("<link") == 1  # 1 OtherComponent
+        assert rendered.count("<style") == 1  # 1 Style


### PR DESCRIPTION
## description
There is a bug while rendering dependencies of a `component` inside a `partial template` which is included via an `inclusion_tag` in a main template containing `html`, `header` and `body` rendered with the `document` `deps_strategy`.

The template rendered by the `inclusion_tag`, try to use the `deps_strategy=document` but there is no `{% component_css_dependencies %}` or `{% component_js_dependencies %}` in this template.
So, when the function `render_dependencies` is applied, dependencies PLACEHOLDER are removed because there is no place where to move dependencies.

**This result in missing dependencies for `components` only used in an `inclusion_tag`.**

## Potential solution
I've found that forcing `{"DJC_DEPS_STRATEGY": 'ignore'}` context variable in the inclusion_tag is solving the issue.
But i think this should be handled automatically.

## Thoughts
We can discuss about the necessity of an `inclusion_tag` when you have a wonderful app named `django_components` :muscle:  . But well, that an other subject.


I hope this help somehow. I'm here to help or explain more if needed.
Thank you again for your great work !