### PR TITLE
docs: fix example

### DIFF
--- a/docs/concepts/fundamentals/html_attributes.md
+++ b/docs/concepts/fundamentals/html_attributes.md
@@ -608,10 +608,9 @@ class MyComp(Component):
     """
 
     def get_template_data(self, args, kwargs, slots, context):
-        date = kwargs.pop("date")
         return {
-            "date": date,
-            "attrs": kwargs,
+            "date": kwargs["date"],
+            "attrs": kwargs.get("attrs", {}),
             "class_from_var": "extra-class"
         }
 


### PR DESCRIPTION
This fixes the code example regarding `{% html_attrs %}` usage.

The new code now seems to work properly, see the attributes of the `<div>` element:

<img width="597" height="111" alt="Screenshot 2025-09-23 at 09 50 59" src="https://github.com/user-attachments/assets/0ec9dee4-fdf6-4526-a05f-90f7ca5ba682" />

Closes https://github.com/django-components/django-components/issues/1402