### PR TITLE
refactor: allow to call Component.inject() outside of render

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django_components"
-version = "0.141.5"
+version = "0.141.6"
 requires-python = ">=3.8, <4.0"
 description = "A way to create simple reusable template components in Django."
 keywords = ["django", "components", "css", "js", "html"]
@@ -180,8 +180,9 @@ known-first-party = ["django_components"]
 check_untyped_defs = true
 ignore_missing_imports = true
 exclude = [
-    "test_structures",
     "build",
+    "sampleproject",
+    "test_structures",
 ]
 
 [[tool.mypy.overrides]]

--- a/src/django_components/extensions/defaults.py
+++ b/src/django_components/extensions/defaults.py
@@ -73,6 +73,9 @@ def _extract_defaults(defaults: Optional[Type]) -> List[ComponentDefaultField]:
 
         default_field = getattr(defaults, default_field_key)
 
+        if isinstance(default_field, property):
+            continue
+
         # If the field was defined with dataclass.field(), take the default / factory from there.
         if isinstance(default_field, Field):
             if default_field.default is not MISSING:

--- a/src/django_components/extensions/view.py
+++ b/src/django_components/extensions/view.py
@@ -161,6 +161,9 @@ class ComponentView(ExtensionComponentConfig, View):
         ComponentExtension.ComponentConfig.__init__(self, component)
         View.__init__(self, **kwargs)
 
+        # TODO_v1 - Remove. Superseded by `component_cls`. This was used for backwards compatibility.
+        self.component = component
+
     @property
     def url(self) -> str:
         """

--- a/src/django_components/perfutil/component.py
+++ b/src/django_components/perfutil/component.py
@@ -8,7 +8,7 @@ from django_components.constants import COMP_ID_LENGTH
 from django_components.util.exception import component_error_message
 
 if TYPE_CHECKING:
-    from django_components.component import ComponentContext, OnRenderGenerator
+    from django_components.component import Component, ComponentContext, OnRenderGenerator
 
 OnComponentRenderedResult = Tuple[Optional[str], Optional[Exception]]
 
@@ -29,6 +29,15 @@ OnComponentRenderedResult = Tuple[Optional[str], Optional[Exception]]
 # `ComponentContext` data on a separate dictionary, and what's passed through the Context
 # is only a key to this dictionary.
 component_context_cache: Dict[str, "ComponentContext"] = {}
+
+# ComponentID -> Component instance mapping
+# This is used so that we can access the component instance from inside `on_component_rendered()`,
+# to call `Component.on_render_after()`.
+# These are strong references to ensure that the Component instance stays alive until after
+# `on_component_rendered()` has been called.
+# After that, we release the reference. If user does not keep a reference to the component,
+# it will be garbage collected.
+component_instance_cache: Dict[str, "Component"] = {}
 
 
 class ComponentPart(NamedTuple):

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -680,7 +680,11 @@ class SlotNode(BaseNode):
         # Component info
         component_id: str = context[_COMPONENT_CONTEXT_KEY]
         component_ctx = component_context_cache[component_id]
-        component = component_ctx.component
+        component = component_ctx.component()
+        if component is None:
+            raise RuntimeError(
+                f"Component with id '{component_id}' was garbage collected before its slots could be rendered."
+            )
         component_name = component.name
         component_path = component_ctx.component_path
         is_dynamic_component = getattr(component, "_is_dynamic_component", False)
@@ -828,7 +832,12 @@ class SlotNode(BaseNode):
             if parent_index is not None:
                 ctx_id_with_fills = context.dicts[parent_index][_COMPONENT_CONTEXT_KEY]
                 ctx_with_fills = component_context_cache[ctx_id_with_fills]
-                slot_fills = ctx_with_fills.component.raw_slots
+                parent_component = ctx_with_fills.component()
+                if parent_component is None:
+                    raise RuntimeError(
+                        f"Component with id '{component_id}' was garbage collected before its slots could be rendered."
+                    )
+                slot_fills = parent_component.raw_slots
 
                 # Add trace message when slot_fills are overwritten
                 trace_component_msg(

--- a/tests/templates/inject.html
+++ b/tests/templates/inject.html
@@ -1,5 +1,5 @@
 {% load component_tags %}
 <div>
-  {% component "injectee" %}
+  {% component "injectee17" %}
   {% endcomponent %}
 </div>

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -736,8 +736,18 @@ class TestSlot:
         assert len(seen_slots) == 3
 
         results = [slot().strip() for slot in seen_slots]
-        assert results == [
-            "<!-- _RENDERED MyInnerComponent_fb676b,ca1bc49,, -->Hello!",
-            "<!-- _RENDERED MyInnerComponent_fb676b,ca1bc4a,, -->Hello!",
-            "<!-- _RENDERED MyInnerComponent_fb676b,ca1bc4b,, -->Hello!",
-        ]
+
+        if components_settings["context_behavior"] == "django":
+            assert results == [
+                "<!-- _RENDERED MyInnerComponent_fb676b,ca1bc49,, -->Hello!",
+                "<!-- _RENDERED MyInnerComponent_fb676b,ca1bc4a,, -->Hello!",
+                "<!-- _RENDERED MyInnerComponent_fb676b,ca1bc4b,, -->Hello!",
+            ]
+        else:
+            # TODO - Incorrect for slots!
+            #        To be fixed in https://github.com/django-components/django-components/issues/1259
+            assert results == [
+                '<template djc-render-id="ca1bc49"></template>',
+                '<template djc-render-id="ca1bc4a"></template>',
+                '<template djc-render-id="ca1bc4b"></template>',
+            ]


### PR DESCRIPTION
There was an error I encountered in https://github.com/django-components/django-components/pull/1411 (see [broken pipeline](https://github.com/django-components/django-components/actions/runs/18004778853/job/51222326796?pr=1411)).

It happens when provided data were accessed from within a component that's inside a forloop:

```py
class MyComponent(Component):
   def get_template_data(self, args, kwargs, slots, context):
       data = self.inject("my_provide")
       return {"data": data}
```

```django
{% load component_tags %}
{% provide "my_provide" key="hi" data=data %}
   {% for i in range(10) %}
       {% component "my_component" / %}
   {% endfor %}
{% endprovide %}
```

To fix the error, I changed how the provided data is managed.

- Previously, it was done entirely within the Django's Context object. We counted refences to the provided data, and removed it when the reference dropped to 0, or when the `{% provide %}` block ended.

   This was incorrect, because the reference count could drop to 0 even between components of the same depth:

   ```django
	{% load component_tags %}
	{% provide "my_provide" key="hi" data=data %}
     {# <-- 0 comps refer to "my_provide" #}
	   {% for i in range(10) %}
           {# <-- 0 comps refer to "my_provide" #}
	       {% component "my_component" / %}  {# <-- 1 comp refers to "my_provide" #}
           {# <-- 0 comps refer to "my_provide" #}
	   {% endfor %}
	{% endprovide %}
   ```

- So now, instead, the reference counting is done differently:
   - When we reach `{% endprovide %}`, we remove the provided data, UNLESS there's a component instance pointing to it.
   - We use [finalizers](https://docs.python.org/3/library/weakref.html#weakref.finalize) to detect when Component instances are garbage collected. And when they are, only then we check whether we can release the provided data or not.

The side effect of this new approach is that `Component.inject()` will now work also outside of rendering flow

 ```py
 comp = None

 class MyComponent(Component):
     def get_template_data(self, args, kwargs, slots, context):
         nonlocal comp
         comp = self

 template_str = """
     {% load component_tags %}
     {% provide "my_provide" key="hi" data=data %}
         {% component "my_component" / %}
     {% endprovide %}
 """
 template = Template(template_str)
 rendered = template.render(Context({}))

 assert comp is not None

 injected = comp.inject("my_provide")
 assert injected.key == "hi"
 assert injected.data == "data"
 ```