### PR TITLE
refactor: make djc compatible with django-template-partials v23.3 and later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.142.3
 
+#### Fix
+
+- Fixed compatibility with older versions of django-template-partials. django-components now works with django-template-partials v23.3 and later. (See [#1455](https://github.com/django-components/django-components/issues/1455))
+
 #### Refactor
 
 - `Component.View.public = True` is now optional.

--- a/docs/overview/compatibility.md
+++ b/docs/overview/compatibility.md
@@ -23,3 +23,13 @@ django-components is tested against Ubuntu and Windows, and should work on any o
     This should cover most of the cases.
 
     However, if your environment is not supported, you will need to install Rust and Cargo to build the sub-packages from source.
+
+### Other packages
+
+Here we track which other packages from the Django ecosystem we try to be compatible with.
+
+How to read this table - E.g. in case of `django-template-partials`, you should use at least version `0.142.3` of `django-components` and at least version `23.3` of django-template-partials.
+
+| Package | django-components version | Package version |
+| -------------- | -------------- | --- |
+[`django-template-partials`](https://github.com/carltongibson/django-template-partials) | >=0.142.3            | >=23.3            |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,8 +12,6 @@ asv==0.6.5
     # via -r requirements-dev.in
 asv-runner==0.2.1
     # via asv
-backports-asyncio-runner==1.2.0
-    # via pytest-asyncio
 build==1.3.0
     # via asv
 cachetools==6.2.0

--- a/src/django_components/util/django_monkeypatch.py
+++ b/src/django_components/util/django_monkeypatch.py
@@ -353,6 +353,17 @@ def monkeypatch_template_proxy_render(template_proxy_cls: Type[Any]) -> None:
 
     template_proxy_cls.render = _template_proxy_render
 
+    # TemplateProxy from django-template-partials replicates Template.render().
+    # However, the older versions (e.g. 24.1) didn't define `_render()` method.
+    # So we define it to support the older versions of django-template-partials.
+    # With this, we support django-template-partials as old as v23.3.
+    if not hasattr(template_proxy_cls, "_render"):
+
+        def _render(self: Any, context: Context, *args: Any, **kwargs: Any) -> str:
+            return self.nodelist.render(context, *args, **kwargs)
+
+        template_proxy_cls._render = _render
+
 
 def is_cls_patched(cls: Type[Any]) -> bool:
     return getattr(cls, "_djc_patched", False)

--- a/tests/test_integration_template_partials.py
+++ b/tests/test_integration_template_partials.py
@@ -28,6 +28,7 @@ except ImportError:
 setup_test_config()
 
 
+# Test compatibility with django-template-partials.
 # See https://github.com/django-components/django-components/issues/1323#issuecomment-3156654329
 @djc_test(django_settings={"INSTALLED_APPS": ("template_partials", "django_components", "tests.test_app")})
 class TestTemplatePartialsIntegration:


### PR DESCRIPTION
Add `_render()` method to `TemplateProxy` from `django-template-partials`. This makes django-components compatible with `django-template-partials` as old as v23.3.

I also added a section to the compatibility page on compatibility with other packages, where we can document the situation.

Closes https://github.com/django-components/django-components/issues/1455

<img width="605" height="337" alt="Screenshot 2025-10-17 at 10 45 14" src="https://github.com/user-attachments/assets/e518221e-fb68-4d84-83d8-551427e88aff" />
