### PR TITLE
refactor: do not call URLResolver._populate() if not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## v0.143.1
+
+#### Fix
+
+- Make django-component's position in Django's `INSTALLED_APPS` more lenient by not calling Django's `URLResolver._populate()` if `URLResolver` hasn't been resolved before ([See thread](https://discord.com/channels/1417824875023700000/1417825089675853906/1437034834118840411)).
+
 ## v0.143.0
 
 #### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django_components"
-version = "0.143.0"
+version = "0.143.1"
 requires-python = ">=3.8, <4.0"
 description = "A way to create simple reusable template components in Django."
 keywords = ["django", "components", "css", "js", "html"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,8 +12,6 @@ asv==0.6.5
     # via -r requirements-dev.in
 asv-runner==0.2.1
     # via asv
-backports-asyncio-runner==1.2.0
-    # via pytest-asyncio
 build==1.3.0
     # via asv
 cachetools==6.2.0

--- a/src/django_components/util/testing.py
+++ b/src/django_components/util/testing.py
@@ -585,5 +585,11 @@ def _clear_djc_global_state(
     if gc_collect:
         gc.collect()
 
+    # Clear Django's URL resolver cache, so that any URLs that were added
+    # during tests are removed.
+    from django.urls.resolvers import _get_cached_resolver  # noqa: PLC0415
+
+    _get_cached_resolver.cache_clear()
+
     global IS_TESTING  # noqa: PLW0603
     IS_TESTING = False

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -5,6 +5,7 @@ import pytest
 from django.http import HttpRequest, HttpResponse
 from django.template import Context, Origin, Template
 from django.test import Client
+from django.urls import get_resolver, get_urlconf
 
 from django_components import Component, Slot, SlotNode, register, registry
 from django_components.app_settings import app_settings
@@ -649,6 +650,12 @@ class TestExtensionHooks:
 
 @djc_test
 class TestExtensionViews:
+    @djc_test(components_settings={"extensions": [DummyExtension]})
+    def test_resolver_not_populated_needlessly(self):
+        urlconf = get_urlconf()
+        resolver = get_resolver(urlconf)
+        assert not resolver._populated
+
     @djc_test(components_settings={"extensions": [DummyExtension]})
     def test_views(self):
         client = Client()


### PR DESCRIPTION
Fix for [this issue reported in Discord](https://discord.com/channels/1417824875023700000/1417825089675853906/1437034834118840411).

Copied below in case that link dies:

---

Joey:

> Hello, I just tried installing django-components in our project, however it seems like django-components is doing things to url patterns? I didn't even yet include django-components to the url_patterns like stated in the "Getting started" but yet suddenly I can't run the project anymore:
> 
> We use a plugin system, where plugins can contribute to the url patterns and this now seems to break:
> 
> ```
>   File "/Users/joey/projects/voxyan/kitchensink/sources/ocyan.plugin.oscar/ocyan/plugin/oscar/shared/entrypoint.py", line 41, in contribute_to_urlpatterns
>     new_patterns = [path("", application.urls)]
>                              ^^^^^^^^^^^^^^^^
>   File "/Users/joey/projects/voxyan/kitchensink/sources/ocyan.plugin.oscar/ocyan/plugin/oscar/shared/appconfig.py", line 156, in urls
>     return self.get_urls(), None, None
>            ^^^^^^^^^^^^^^^
>   File "/Users/joey/projects/voxyan/kitchensink/sources/ocyan.plugin.oscar/ocyan/plugin/oscar/shared/appconfig.py", line 152, in get_urls
>     return self.get_new_urls() + self.get_old_urls()
>            ^^^^^^^^^^^^^^^^^^^
>   File "/Users/joey/projects/voxyan/kitchensink/sources/ocyan.plugin.oscar/ocyan/plugin/oscar/shared/appconfig.py", line 103, in get_new_urls
>     path("", self.catalogue_app.urls),
>              ^^^^^^^^^^^^^^^^^^
> AttributeError: 'Shop' object has no attribute 'catalogue_app'
> ```
> 
> And when I look a little bit up in the traceback, it seems like django-components is doing some things by default to the url patterns? 
> 
> ```
>   File "/Users/joey/projects/voxyan/kitchensink/.venv/lib/python3.11/site-packages/django_components/apps.py", line 77, in ready
>     extensions._init_app()
>   File "/Users/joey/projects/voxyan/kitchensink/.venv/lib/python3.11/site-packages/django_components/extension.py", line 1168, in _init_app
> ```
> 
> Can I disable this somehow?

Juro:

> Hey <@395697396643921931> , when/how is the `contribute_to_urlpatterns` called? At a first glance it looks like maybe it could be resolved if django-components would be loaded after other Django apps (if `contribute_to_urlpatterns` is loaded as a Django app)

Joey:

> We have a base urls.py in on of our core packages;
> 
> ```python
> urlpatterns = [
>     path(r"~startup/", startup),
> ]
> if config.i18n_enabled:
>     urlpatterns = i18n_patterns(*urlpatterns, prefix_default_language=False)
> 
> # https://github.com/ironfroggy/straight.plugin
> urlpatterns = plugins.pipe("contribute_to_urlpatterns", urlpatterns)
> ```
> 
> This core package then also sets this url conf as `ROOT_URLCONF` (in settings)
> 
> All our projects import settings from this core package, which mean they inherit the urls and all other things plugins have contributed.
> 
> So the contribute_to_urlpatterns really is called when django loads urls defined in `ROOT_URLCONF`
> 
> You're saying django-components should be the last app?

Joey:

> Right. So adding to to the end seems to resolve it?
> 
> I don't really have much control of the app order though, we use something we call "segmented" apps to control the order,.
> 
> django first, then others (some other pre-defined groups).
> 
> However, projects inherit from this core package but can still add custom apps.
> 
> If we need to enforce django-components to be last, that's kind of difficult really.
> 
> Just curious, why does django-component needs to be last?

Juro:

> Just looked up [the code](https://github.com/django-components/django-components/blob/39e4d78dc5928090424e4e3b06afec4aa75f00e9/src/django_components/extension.py#L1168). It's to allow django-component's extensions to add routes to Django's `urlpatterns` dynamically.
> 
> Example use case is the `Component.View` nested class. Where if you define a method, e.g. `Component.View.post`, then you will be able to automatically generate the endpoint URL with `get_component_url()` without having to touch Django's `urlpatterns`.
> 
> The issue with Django's urlpatterns is that if you add a path to `urlpatterns` after the resolver (router) has been initialized, then the new path will NOT be resolvable - calling `django.urls.reverse(path)` will fail to find the new path.
> 
> So as a workaround what django-components does currently is that after the extensions have inserted their paths, we trigger the resolver to "populate" (rebuild) the paths.
> 
> If I remember correctly, `resolver._populate()` would be otherwise called the first time you call e.g. `{% url %}` or `django.urls.reverse()`.
> 
> So what's likely happening in your case is that django-components' internals cause the resolver to be built sooner than when it would be otherwise called in your app.
> 
> So yes, placing django-components last should resolve this.
> 
> What is the `Shop.catalogue_app` attribute that's undefined? Is that your custom object? Or Django's `AppConfig`? When/how is that defined?
>
> Btw the "segmented apps" that you've mentioned, is it an in-house solution or some public package?
>
> Potentially one fix could be that django-components would call Django's `resolver._populate()` only if the resolver has been already populated before. That could fix your issue.

Joey:

> It's a class based upon django's AppConfig but with extra functionality:
> 
> https://github.com/django-oscar/django-oscar/blob/master/src/oscar/config.py#L12
> 
> https://github.com/django-oscar/django-oscar/blob/master/src/oscar/core/application.py
> 
> And yes, the segmented apps is a in-house solution. Which uses https://github.com/ironfroggy/straight.plugin for resolving plugin contributed functionality (urls, apps, settings, middlewares etc)
> 
> Most of them are loaded in the core package's settings.py - where all projects inherit from.

Juro:

> Are you running the project locally? Could you try if the following fixes it?
> 
> On [line 1168](https://github.com/django-components/django-components/blob/39e4d78dc5928090424e4e3b06afec4aa75f00e9/src/django_components/extension.py#L1168), wrap the `_populate()` call in an if statement:
> 
> ```py
> if resolver._populated:
>     resolver._populate()
> ```

Joey:

> It seems like it's not populated yet though, when I print the dict of resolver:
> 
> ```
> resolver:  {'pattern': <django.urls.resolvers.RegexPattern object at 0x109969050>, 'urlconf_name': 'ocyan.main.urls', 'callback': None, 'default_kwargs': {}, 'namespace': None, 'app_name': None, '_reverse_dict': {}, '_namespace_dict': {}, '_app_dict': {}, '_callback_strs': set(), '_populated': False, '_local': <asgiref.local.Local object at 0x109968f10>}
> ```
> 
> It says _populated: False.

Joey:

> Right. Yeah then the app doesn't crash anymore.
> 
> But will the component views still work as expected then? (I don't know enough about the internals)