### PR TITLE
refactor: raise when template data overwrites variables from context_processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Make django-component's position in Django's `INSTALLED_APPS` more lenient by not calling Django's `URLResolver._populate()` if `URLResolver` hasn't been resolved before ([See thread](https://discord.com/channels/1417824875023700000/1417825089675853906/1437034834118840411)).
 
+#### Refactor
+
+- Components now raise error if template data overwrites variables from `context_processors` ([#1482](https://github.com/django-components/django-components/issues/1482))
+
 ## v0.143.0
 
 #### Feat


### PR DESCRIPTION
When constructing the variables available to the context, the data comes from 2 sources:
- from `Component.get_template_data()` (or old `get_context_data`)
- from Django's context processors

Currently, when these conflict, the context processors silently overwrite the component's own data.

To improve user experience, this PR turns this into an error, so users are made aware of this conflict.

Closes https://github.com/django-components/django-components/issues/1482