### PR TITLE
refactor: Move used github variables to be defined in env section

### DIFF
--- a/.github/workflows/discussion-discord.yml
+++ b/.github/workflows/discussion-discord.yml
@@ -11,14 +11,20 @@ jobs:
       - name: Post to Discord (development channel)
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_DEVELOPMENT }}
+          TITLE: ${{ github.event.discussion.title }}
+          URL: ${{ github.event.discussion.html_url }}
+          USER: ${{ github.event.discussion.user.login }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.discussion.number }}
+          TS: ${{ github.event.discussion.created_at }}
         run: |
           payload=$(jq -n \
-            --arg title "${{ github.event.discussion.title }}" \
-            --arg url "${{ github.event.discussion.html_url }}" \
-            --arg user "${{ github.event.discussion.user.login }}" \
-            --arg repo "${{ github.repository }}" \
-            --arg number "#${{ github.event.discussion.number }}" \
-            --arg timestamp "${{ github.event.discussion.created_at }}" \
+            --arg title "$TITLE" \
+            --arg url "$URL" \
+            --arg user "$USER" \
+            --arg repo "$REPO" \
+            --arg number "#$NUMBER" \
+            --arg timestamp "$TS" \
             '{
               "username": "GitHub Discussions",
               "avatar_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",

--- a/.github/workflows/issue-discord.yml
+++ b/.github/workflows/issue-discord.yml
@@ -11,14 +11,20 @@ jobs:
       - name: Post to Discord (development channel)
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_DEVELOPMENT }}
+          TITLE: ${{ github.event.issue.title }}
+          URL: ${{ github.event.issue.html_url }}
+          USER: ${{ github.event.issue.user.login }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          TS: ${{ github.event.issue.created_at }}
         run: |
           payload=$(jq -n \
-            --arg title "${{ github.event.issue.title }}" \
-            --arg url "${{ github.event.issue.html_url }}" \
-            --arg user "${{ github.event.issue.user.login }}" \
-            --arg repo "${{ github.repository }}" \
-            --arg number "#${{ github.event.issue.number }}" \
-            --arg timestamp "${{ github.event.issue.created_at }}" \
+            --arg title "$TITLE" \
+            --arg url "$URL" \
+            --arg user "$USER" \
+            --arg repo "$REPO" \
+            --arg number "#$NUMBER" \
+            --arg timestamp "$TS" \
             '{
               "username": "GitHub Issues",
               "avatar_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",

--- a/.github/workflows/pr-benchmark-generate.yml
+++ b/.github/workflows/pr-benchmark-generate.yml
@@ -26,8 +26,10 @@ jobs:
         fetch-depth: 0  # Need full history for ASV
 
     - name: Fetch base branch
+      env:
+        REPO: ${{ github.repository }}
       run: |
-        git remote add upstream https://github.com/${{ github.repository }}.git
+        git remote add upstream https://github.com/$REPO.git
         git fetch upstream master
 
     - name: Set up Python
@@ -44,6 +46,8 @@ jobs:
         pip install asv virtualenv==20.30
 
     - name: Run benchmarks
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         # TODO: REMOVE ONCE FIXED UPSTREAM
         # Fix for https://github.com/airspeed-velocity/asv_runner/issues/45
@@ -73,7 +77,7 @@ jobs:
         # We assume that the CI machine has a name that is unique and stable.
         # See https://github.com/airspeed-velocity/asv/issues/796#issuecomment-1188431794
         echo "Preparing benchmarks profile..."
-        MACHINE="ci_benchmark_${{ github.event.pull_request.number }}"
+        MACHINE="ci_benchmark_${PR_NUMBER}"
         asv machine --yes -v --machine ${MACHINE}
         echo "Benchmarks profile DONE."
 
@@ -95,7 +99,7 @@ jobs:
         echo "Creating pr directory..."
         mkdir -p pr
         # Save the PR number to a file, so that it can be used by the next step.
-        echo "${{ github.event.pull_request.number }}" > ./pr/pr_number.txt
+        echo "$PR_NUMBER" > ./pr/pr_number.txt
 
         # Compare against master
         # NOTE: The command is run twice, once so we can see the debug output, and once to save the results.

--- a/.github/workflows/release-discord.yml
+++ b/.github/workflows/release-discord.yml
@@ -11,14 +11,20 @@ jobs:
       - name: Post to Discord (announcements channel)
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCEMENTS }}
+          NAME: ${{ github.event.release.name || github.event.release.tag_name }}
+          URL: ${{ github.event.release.html_url }}
+          BODY: ${{ github.event.release.body }}
+          USER: ${{ github.event.release.author.login }}
+          REPO: ${{ github.repository }}
+          TS: ${{ github.event.release.published_at }}
         run: |
           payload=$(jq -n \
-            --arg name "${{ github.event.release.name || github.event.release.tag_name }}" \
-            --arg url "${{ github.event.release.html_url }}" \
-            --arg body "${{ github.event.release.body }}" \
-            --arg user "${{ github.event.release.author.login }}" \
-            --arg repo "${{ github.repository }}" \
-            --arg timestamp "${{ github.event.release.published_at }}" \
+            --arg name "$NAME" \
+            --arg url "$URL" \
+            --arg body "$BODY" \
+            --arg user "$USER" \
+            --arg repo "$REPO" \
+            --arg timestamp "$TS" \
             '{
               "username": "GitHub Releases",
               "avatar_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -73,9 +73,10 @@ jobs:
           # See https://github.com/github/docs/issues/21930
           # And https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
           # Get the master branch so we can run benchmarks on it
-          git remote add upstream https://github.com/${{ github.repository }}.git
+          git remote add upstream https://github.com/$REPO.git
           git fetch origin master:master
           git checkout master
 
@@ -186,6 +187,8 @@ jobs:
 
       - name: Build & deploy docs for a new tag
         if: github.ref_type == 'tag' && github.event_name == 'push'
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # Fetch and checkout gh-pages to ensure we have the latest version
           git fetch origin gh-pages
@@ -193,5 +196,5 @@ jobs:
           git pull origin gh-pages
           git checkout master
 
-          mike deploy --push --update-aliases ${{ github.ref_name }} latest
+          mike deploy --push --update-aliases $REF_NAME latest
           mike set-default latest --push


### PR DESCRIPTION
Follow up for https://github.com/django-components/django-components/pull/1511.

This applies the same thing - accessing github metadata in the `env` section, instead of directly in the script - but for the remaining scripts, so things are consistent.