### PR TITLE
Add ownership tag to index.html and add robots.txt

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Redirecting</title>
+  <meta name="google-site-verification" content="vQA3d50F2ByQxG0eB6b0YoPnYW9gZo8xnd6HKhCyuys">
+  <title>Redirecting to latest django-components documentation</title>
   <noscript>
     <meta http-equiv="refresh" content="1; url=latest/" />
   </noscript>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+user-agent: *
+
+sitemap: https://django-components.github.io/django-components/latest/sitemap.xml


### PR DESCRIPTION
This hopefully closes #1355 by adding the ownership tag to the index.html page at root. The PR also adds a `robots.txt` to the root of gh-pages linking to the `sitemap.xml` file of the latest documentation.