### PR TITLE
tests: run E2E tests also against firefox and webkit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ Always reference these instructions first and fallback to search or bash command
   - `pip install -r requirements-dev.txt` -- installs all dev dependencies including pytest, ruff, etc.
   - `pip install -e .` -- install the package in development mode
 - Install Playwright for browser testing (optional, may timeout):
-  - `playwright install chromium --with-deps` -- NEVER CANCEL: Can take 10+ minutes due to large download. Set timeout to 15+ minutes.
+  - `playwright install chromium firefox webkit --with-deps` -- NEVER CANCEL: Can take 10+ minutes due to large download. Set timeout to 15+ minutes.
 
 ### Building and Testing
 - **NEVER CANCEL BUILDS OR TESTS** -- All timeouts below are validated minimums
@@ -75,7 +75,7 @@ The package provides custom Django management commands:
 ### CI/CD Information  
 - GitHub Actions workflow: `.github/workflows/tests.yml`
 - Tests run on Python 3.8-3.14 with Django 4.2-5.2
-- Includes Playwright browser testing (requires `playwright install chromium --with-deps`)
+- Includes Playwright browser testing (requires `playwright install chromium firefox webkit --with-deps`)
 - Documentation building uses mkdocs
 - Pre-commit hooks run ruff
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Playwright browsers
         run: |
           # See https://playwright.dev/python/docs/intro#installing-playwright-pytest
-          playwright install chromium --with-deps
+          playwright install chromium firefox webkit --with-deps
       - name: Run tests
         run: tox
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.146.0
 
+`django-components` is now tested across all major browsers - Chromium, Firefox, WebKit.
+
 #### Feat
 
 - **Python expressions in template tags.** Evaluate Python code directly in template by wrapping expressions in parentheses:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ in modern frontend frameworks like Vue or React.
 
 With `django-components` you can support Django projects small and large without leaving the Django ecosystem.
 
+`django-components` is tested across all major browsers - Chromium, Firefox, WebKit ✅.
+
 ## Sponsors
 
 <p align="center">

--- a/docs/community/development.md
+++ b/docs/community/development.md
@@ -82,13 +82,15 @@ tox -e mypy,ruff
 
 ## Playwright tests
 
-We use [Playwright](https://playwright.dev/python/docs/intro) for end-to-end tests. You will need to install Playwright to run these tests.
+We use [Playwright](https://playwright.dev/python/docs/intro) for end-to-end tests.
 
-Luckily, Playwright makes it very easy:
+Tests decorated with `@with_playwright` automatically run across all major browsers: Chromium, Firefox, and WebKit. This ensures cross-browser compatibility.
+
+You will need to install Playwright to run these tests. Luckily, Playwright makes it very easy:
 
 ```sh
 pip install -r requirements-dev.txt
-playwright install chromium --with-deps
+playwright install chromium firefox webkit --with-deps
 ```
 
 After Playwright is ready, run the tests the same way as before:
@@ -106,7 +108,7 @@ tox -e py38
     If `tox -e py38` fails with "Executable doesn't exist", install the browsers using the Playwright inside that tox env:
 
     ```sh
-    .tox/py38/bin/python -m playwright install chromium
+    .tox/py38/bin/python -m playwright install chromium firefox webkit
     ```
 
 ## Snapshot tests

--- a/docs/overview/welcome.md
+++ b/docs/overview/welcome.md
@@ -7,6 +7,8 @@ in modern frontend frameworks like Vue or React.
 
 With `django-components` you can support Django projects small and large without leaving the Django ecosystem.
 
+`django-components` is tested across all major browsers - Chromium, Firefox, WebKit ✅.
+
 ## Sponsors
 
 <p align="center">

--- a/src/django_components/util/testing.py
+++ b/src/django_components/util/testing.py
@@ -15,6 +15,7 @@ from typing import (
     Set,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 from unittest.mock import patch
@@ -46,6 +47,9 @@ else:
     RegistriesCopies = List[Tuple[ReferenceType, List[str]]]
     InitialComponents = List[ReferenceType]
     RegistryRef = ReferenceType
+
+
+TCallable = TypeVar("TCallable", bound=Callable[..., Any])
 
 
 # Whether we're inside a test that was wrapped with `djc_test`.
@@ -125,7 +129,7 @@ def djc_test(
         ]
     ] = None,
     gc_collect: bool = True,
-) -> Callable:
+) -> Callable[[TCallable], TCallable]:
     """
     Decorator for testing components from django-components.
 
@@ -417,7 +421,7 @@ def djc_test(
         return decorator(django_settings)
 
     # Handle `@djc_test(settings)`
-    return decorator
+    return decorator  # type: ignore[return-value]
 
 
 def _merge_django_settings(

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -57,7 +57,7 @@ async def _create_page_with_dep_manager(browser: Browser) -> Page:
 )
 class TestDependencyManager:
     @with_playwright
-    async def test_script_loads(self):
+    async def test_script_loads(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         # Check the exposed API
@@ -85,7 +85,7 @@ class TestDependencyManager:
 )
 class TestLoadScript:
     @with_playwright
-    async def test_load_js_scripts(self):
+    async def test_load_js_scripts(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         # JS code that loads a few dependencies, capturing the HTML after each action
@@ -129,7 +129,7 @@ class TestLoadScript:
         await page.close()
 
     @with_playwright
-    async def test_load_css_scripts(self):
+    async def test_load_css_scripts(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         # JS code that loads a few dependencies, capturing the HTML after each action
@@ -173,7 +173,7 @@ class TestLoadScript:
         await page.close()
 
     @with_playwright
-    async def test_does_not_load_script_if_marked_as_loaded(self):
+    async def test_does_not_load_script_if_marked_as_loaded(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         # JS code that loads a few dependencies, capturing the HTML after each action
@@ -212,7 +212,7 @@ class TestLoadScript:
 )
 class TestCallComponent:
     @with_playwright
-    async def test_calls_component_successfully(self):
+    async def test_calls_component_successfully(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         test_js: types.js = """() => {
@@ -263,7 +263,7 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_calls_component_successfully_async(self):
+    async def test_calls_component_successfully_async(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         test_js: types.js = """() => {
@@ -303,7 +303,7 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_error_in_component_call_do_not_propagate_sync(self):
+    async def test_error_in_component_call_do_not_propagate_sync(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         test_js: types.js = """() => {
@@ -337,7 +337,7 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_error_in_component_call_do_not_propagate_async(self):
+    async def test_error_in_component_call_do_not_propagate_async(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         test_js: types.js = """() => {
@@ -373,7 +373,7 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_raises_if_component_element_not_in_dom(self):
+    async def test_raises_if_component_element_not_in_dom(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         test_js: types.js = """() => {
@@ -404,7 +404,7 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_raises_if_input_hash_not_registered(self):
+    async def test_raises_if_input_hash_not_registered(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         test_js: types.js = """() => {
@@ -433,7 +433,7 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_raises_if_component_not_registered(self):
+    async def test_raises_if_component_not_registered(self, browser_name):
         page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
 
         test_js: types.js = """() => {

--- a/tests/test_dependency_rendering_e2e.py
+++ b/tests/test_dependency_rendering_e2e.py
@@ -25,7 +25,7 @@ setup_test_config()
 @djc_test
 class TestE2eDependencyRendering:
     @with_playwright
-    async def test_single_component_dependencies(self):
+    async def test_single_component_dependencies(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/single"
 
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
@@ -74,7 +74,7 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_multiple_component_dependencies(self):
+    async def test_multiple_component_dependencies(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/multi"
 
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
@@ -168,7 +168,7 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_renders_css_nojs_env(self):
+    async def test_renders_css_nojs_env(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/multi"
 
         page: Page = await self.browser.new_page(java_script_enabled=False)  # type: ignore[attr-defined]
@@ -263,7 +263,7 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_js_executed_in_order__js(self):
+    async def test_js_executed_in_order__js(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/js-order/js"
 
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
@@ -289,7 +289,7 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_js_executed_in_order__media(self):
+    async def test_js_executed_in_order__media(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/js-order/media"
 
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
@@ -319,7 +319,7 @@ class TestE2eDependencyRendering:
     # is used in the template before the other components. So the JS should
     # not be able to access the data from the other components.
     @with_playwright
-    async def test_js_executed_in_order__invalid(self):
+    async def test_js_executed_in_order__invalid(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/js-order/invalid"
 
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
@@ -345,7 +345,7 @@ class TestE2eDependencyRendering:
 
     # Fragment where JS and CSS is defined on Component class
     @with_playwright
-    async def test_fragment_comp(self):
+    async def test_fragment_comp(self, browser_name):
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/js?frag=comp")
 
@@ -403,7 +403,7 @@ class TestE2eDependencyRendering:
 
     # Fragment where JS and CSS is defined on Media class
     @with_playwright
-    async def test_fragment_media(self):
+    async def test_fragment_media(self, browser_name):
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/js?frag=media")
 
@@ -459,7 +459,7 @@ class TestE2eDependencyRendering:
 
     # Fragment loaded by AlpineJS
     @with_playwright
-    async def test_fragment_alpine(self):
+    async def test_fragment_alpine(self, browser_name):
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/alpine?frag=comp")
 
@@ -518,7 +518,7 @@ class TestE2eDependencyRendering:
 
     # Fragment loaded by HTMX
     @with_playwright
-    async def test_fragment_htmx(self):
+    async def test_fragment_htmx(self, browser_name):
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/htmx?frag=comp")
 
@@ -570,7 +570,7 @@ class TestE2eDependencyRendering:
 
     # Fragment where the page wasn't rendered with the "document" strategy
     @with_playwright
-    async def test_fragment_without_document(self):
+    async def test_fragment_without_document(self, browser_name):
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/htmx_raw?frag=comp")
 
@@ -627,7 +627,7 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_alpine__head(self):
+    async def test_alpine__head(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/alpine/head"
 
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
@@ -639,7 +639,7 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_alpine__body(self):
+    async def test_alpine__body(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/alpine/body"
 
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
@@ -651,7 +651,7 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_alpine__body2(self):
+    async def test_alpine__body2(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/alpine/body2"
 
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
@@ -663,7 +663,7 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_alpine__invalid(self):
+    async def test_alpine__invalid(self, browser_name):
         single_comp_url = TEST_SERVER_URL + "/alpine/invalid"
 
         page: Page = await self.browser.new_page()  # type: ignore[attr-defined]


### PR DESCRIPTION
https://github.com/django-components/django-components/issues/1544 exposed that different browsers may behave differently, and that Firefox is currently broken.

This PR updates E2E (Playwright) tests to run also against Firefox and Webkit (Safari). Previously, we tested only against Chromium (Chrome, Edge).

The tests for this PR are expected to fail, as we finally capture the error found in https://github.com/django-components/django-components/issues/1544:

(Notice that all the failing tests end with `[firefox]`)

<img width="775" height="170" alt="Screenshot 2026-01-22 at 17 08 34" src="https://github.com/user-attachments/assets/8b2c38b2-2769-4f52-9953-72491c36d52b" />
