### PR TITLE
refactor: load component template and JS/CSS files separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,14 @@
             assert kwargs.user == { "name": "John" }
     ```
 
+#### Refactor
+
+- Component's JS, CSS, and HTML template are now loaded independently.
+
+    This means that accessing `Component.js` or `Component.css` no longer triggers template resolution.
+
+    This should improve server startup time as fewer files need to be loaded up front.
+
 ## v0.145.0
 
 #### Perf


### PR DESCRIPTION
## Context

Components can have fields `css_file`, `js_file`, `template_file` to load CSS/JS/HTML from files.

Right now, it's automagically loaded when you access any of the fields like `Component.js`, `Component.js_file`, etc.

However, we load all 3 - JS, CSS, HTML - at the same time.

There's also following edge case:

User may load a page first, then the server restarts, and user's browser only afterwards requests JS/CSS for individual components.

How this is currently addressed is that at the start of the server, we take the JS/CSS files of all components, and cache them, so they can be served.

Now, because we load all 3 JS/CSS/HTML together, that means that we're also loading all HTML templates at the start of the server.

It would be better to load HTML templates lazily, because templates contain `{% component %}` tags that refer to other Component classes, and creating the `Template` instances could with that. Ideally, by the time we load the first template, we already know about all the Component classes created in the project.

**(NOTE: Ideally we'd rework how the JS/CSS caching works, so that it can be accessed lazily. So even if user's browser makes a request to fetch JS/CSS of a specific component, we should be able to, at that point, lazily load the JS/CSS from the file if not yet loaded)**

## Changes

So this PR decouples the loading of Component's JS/CSS files and HTML template.