### PR TITLE
refactor: reuse browsers across playwright tests for faster tests

### DIFF
--- a/docs/community/development.md
+++ b/docs/community/development.md
@@ -84,6 +84,22 @@ We use [Playwright](https://playwright.dev/python/docs/intro) for end-to-end tes
 
 Tests decorated with `@with_playwright` automatically run across all major browsers: Chromium, Firefox, and WebKit. This ensures cross-browser compatibility.
 
+Test functions must include the `browser` and `browser_name` fixtures to work correctly.
+
+```py
+from django_components.testing import djc_test
+from tests.e2e.utils import BrowserType, with_playwright
+from playwright.async_api import Browser
+
+@djc_test
+class MyTest:
+    @with_playwright
+    async def test_script_loads(self, browser: Browser, browser_name: BrowserType):
+        page = await browser.new_page()
+        await page.goto(f"{TEST_SERVER_URL}/my-page")
+        assert page.content() == "My page"
+```
+
 You will need to install Playwright to run these tests. Luckily, Playwright makes it very easy:
 
 ```sh

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,49 @@
-import pytest
+from typing import TYPE_CHECKING
 
-from tests.e2e.utils import run_django_dev_server
+import pytest
+import pytest_asyncio
+from playwright.async_api import Playwright, async_playwright
+
+from tests.e2e.utils import BROWSER_NAMES, BrowserType, _launch_browser, run_django_dev_server
+
+if TYPE_CHECKING:
+    from _pytest.fixtures import FixtureRequest
 
 
 @pytest.fixture(scope="session", autouse=True)
 def django_dev_server():
     """Fixture to run Django development server in the background."""
     yield from run_django_dev_server()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def playwright():
+    """Session-scoped fixture to create a single Playwright instance for all tests."""
+    pw = await async_playwright().start()
+    yield pw
+    await pw.stop()
+
+
+@pytest.fixture(scope="session", params=BROWSER_NAMES, ids=BROWSER_NAMES)
+def browser_name(request: "FixtureRequest") -> BrowserType:
+    """
+    Parametrized fixture that provides the browser name for the current test.
+
+    This fixture is automatically parametrized with all browser types (chromium, firefox, webkit),
+    causing tests to run once per browser type.
+    """
+    browser_name_value = request.param
+    return browser_name_value
+
+
+@pytest_asyncio.fixture(scope="session")
+async def browser(playwright: Playwright, browser_name: BrowserType):
+    """
+    Session-scoped fixture that provides browser instances.
+
+    This fixture depends on `browser_name` (which is parametrized), so it will create
+    one browser instance per browser type that is reused across all tests.
+    """
+    browser = await _launch_browser(playwright, browser_name)
+    yield browser
+    await browser.close()

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -10,6 +10,7 @@ from tests.testutils import setup_test_config
 
 if TYPE_CHECKING:
     from django_components import types
+    from tests.e2e.utils import BrowserType
 
 setup_test_config(
     extra_settings={
@@ -57,8 +58,8 @@ async def _create_page_with_dep_manager(browser: Browser) -> Page:
 )
 class TestDependencyManager:
     @with_playwright
-    async def test_script_loads(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_script_loads(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await _create_page_with_dep_manager(browser)
 
         # Check the exposed API
         keys = sorted(await page.evaluate("Object.keys(DjangoComponents)"))
@@ -78,11 +79,11 @@ class TestDependencyManager:
 
     # TODO_v1: Delete this test in v1
     @with_playwright
-    async def test_backwards_compatibility_components_alias(self, browser_name):
+    async def test_backwards_compatibility_components_alias(self, browser: "Browser", browser_name: "BrowserType"):
         if browser_name == "firefox":
             pytest.skip("Firefox does not support the `Components` global")
 
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+        page = await _create_page_with_dep_manager(browser)
 
         # Verify that Components is still available as an alias
         components_exists = await page.evaluate("typeof Components !== 'undefined'")
@@ -103,8 +104,8 @@ class TestDependencyManager:
 )
 class TestLoadScript:
     @with_playwright
-    async def test_load_js_scripts(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_load_js_scripts(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await _create_page_with_dep_manager(browser)
 
         # JS code that loads a few dependencies, capturing the HTML after each action
         test_js: types.js = """() => {
@@ -147,8 +148,8 @@ class TestLoadScript:
         await page.close()
 
     @with_playwright
-    async def test_load_css_scripts(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_load_css_scripts(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await _create_page_with_dep_manager(browser)
 
         # JS code that loads a few dependencies, capturing the HTML after each action
         test_js: types.js = """() => {
@@ -191,8 +192,8 @@ class TestLoadScript:
         await page.close()
 
     @with_playwright
-    async def test_does_not_load_script_if_marked_as_loaded(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_does_not_load_script_if_marked_as_loaded(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await _create_page_with_dep_manager(browser)
 
         # JS code that loads a few dependencies, capturing the HTML after each action
         test_js: types.js = """() => {
@@ -230,8 +231,8 @@ class TestLoadScript:
 )
 class TestCallComponent:
     @with_playwright
-    async def test_calls_component_successfully(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_calls_component_successfully(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await _create_page_with_dep_manager(browser)
 
         test_js: types.js = """() => {
             const manager = DjangoComponents.createComponentsManager();
@@ -281,8 +282,8 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_calls_component_successfully_async(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_calls_component_successfully_async(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await _create_page_with_dep_manager(browser)
 
         test_js: types.js = """() => {
             const manager = DjangoComponents.createComponentsManager();
@@ -321,8 +322,10 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_error_in_component_call_do_not_propagate_sync(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_error_in_component_call_do_not_propagate_sync(
+        self, browser: "Browser", browser_name: "BrowserType"
+    ):
+        page = await _create_page_with_dep_manager(browser)
 
         test_js: types.js = """() => {
             const manager = DjangoComponents.createComponentsManager();
@@ -355,8 +358,10 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_error_in_component_call_do_not_propagate_async(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_error_in_component_call_do_not_propagate_async(
+        self, browser: "Browser", browser_name: "BrowserType"
+    ):
+        page = await _create_page_with_dep_manager(browser)
 
         test_js: types.js = """() => {
             const manager = DjangoComponents.createComponentsManager();
@@ -391,8 +396,8 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_raises_if_component_element_not_in_dom(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_raises_if_component_element_not_in_dom(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await _create_page_with_dep_manager(browser)
 
         test_js: types.js = """() => {
             const manager = DjangoComponents.createComponentsManager();
@@ -422,8 +427,8 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_raises_if_input_hash_not_registered(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_raises_if_input_hash_not_registered(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await _create_page_with_dep_manager(browser)
 
         test_js: types.js = """() => {
             const manager = DjangoComponents.createComponentsManager();
@@ -451,8 +456,8 @@ class TestCallComponent:
         await page.close()
 
     @with_playwright
-    async def test_raises_if_component_not_registered(self, browser_name):
-        page = await _create_page_with_dep_manager(self.browser)  # type: ignore[attr-defined]
+    async def test_raises_if_component_not_registered(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await _create_page_with_dep_manager(browser)
 
         test_js: types.js = """() => {
             const manager = DjangoComponents.createComponentsManager();

--- a/tests/test_dependency_rendering_e2e.py
+++ b/tests/test_dependency_rendering_e2e.py
@@ -13,9 +13,10 @@ from tests.e2e.utils import TEST_SERVER_URL, with_playwright
 from tests.testutils import setup_test_config
 
 if TYPE_CHECKING:
-    from playwright.async_api import Page
+    from playwright.async_api import Browser
 
     from django_components import types
+    from tests.e2e.utils import BrowserType
 
 setup_test_config()
 
@@ -25,10 +26,10 @@ setup_test_config()
 @djc_test
 class TestE2eDependencyRendering:
     @with_playwright
-    async def test_single_component_dependencies(self, browser_name):
+    async def test_single_component_dependencies(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/single"
 
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+        page = await browser.new_page()
         await page.goto(single_comp_url)
 
         test_js: types.js = """() => {
@@ -74,10 +75,10 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_multiple_component_dependencies(self, browser_name):
+    async def test_multiple_component_dependencies(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/multi"
 
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+        page = await browser.new_page()
         await page.goto(single_comp_url)
 
         test_js: types.js = """() => {
@@ -168,10 +169,10 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_renders_css_nojs_env(self, browser_name):
+    async def test_renders_css_nojs_env(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/multi"
 
-        page: Page = await self.browser.new_page(java_script_enabled=False)  # type: ignore[attr-defined]
+        page = await browser.new_page(java_script_enabled=False)
         await page.goto(single_comp_url)
 
         test_js: types.js = """() => {
@@ -263,10 +264,10 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_js_executed_in_order__js(self, browser_name):
+    async def test_js_executed_in_order__js(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/js-order/js"
 
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+        page = await browser.new_page()
         await page.goto(single_comp_url)
 
         test_js: types.js = """() => {
@@ -289,10 +290,10 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_js_executed_in_order__media(self, browser_name):
+    async def test_js_executed_in_order__media(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/js-order/media"
 
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+        page = await browser.new_page()
         await page.goto(single_comp_url)
 
         test_js: types.js = """() => {
@@ -319,10 +320,10 @@ class TestE2eDependencyRendering:
     # is used in the template before the other components. So the JS should
     # not be able to access the data from the other components.
     @with_playwright
-    async def test_js_executed_in_order__invalid(self, browser_name):
+    async def test_js_executed_in_order__invalid(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/js-order/invalid"
 
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+        page = await browser.new_page()
         await page.goto(single_comp_url)
 
         test_js: types.js = """() => {
@@ -345,8 +346,8 @@ class TestE2eDependencyRendering:
 
     # Fragment where JS and CSS is defined on Component class
     @with_playwright
-    async def test_fragment_comp(self, browser_name):
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+    async def test_fragment_comp(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await browser.new_page()
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/js?frag=comp")
 
         test_before_js: types.js = """() => {
@@ -403,8 +404,8 @@ class TestE2eDependencyRendering:
 
     # Fragment where JS and CSS is defined on Media class
     @with_playwright
-    async def test_fragment_media(self, browser_name):
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+    async def test_fragment_media(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await browser.new_page()
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/js?frag=media")
 
         test_before_js: types.js = """() => {
@@ -459,8 +460,8 @@ class TestE2eDependencyRendering:
 
     # Fragment loaded by AlpineJS
     @with_playwright
-    async def test_fragment_alpine(self, browser_name):
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+    async def test_fragment_alpine(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await browser.new_page()
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/alpine?frag=comp")
 
         test_before_js: types.js = """() => {
@@ -518,8 +519,8 @@ class TestE2eDependencyRendering:
 
     # Fragment loaded by HTMX
     @with_playwright
-    async def test_fragment_htmx(self, browser_name):
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+    async def test_fragment_htmx(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await browser.new_page()
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/htmx?frag=comp")
 
         test_before_js: types.js = """() => {
@@ -570,8 +571,8 @@ class TestE2eDependencyRendering:
 
     # Fragment where the page wasn't rendered with the "document" strategy
     @with_playwright
-    async def test_fragment_without_document(self, browser_name):
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+    async def test_fragment_without_document(self, browser: "Browser", browser_name: "BrowserType"):
+        page = await browser.new_page()
         await page.goto(f"{TEST_SERVER_URL}/fragment/base/htmx_raw?frag=comp")
 
         test_before_js: types.js = """() => {
@@ -627,10 +628,10 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_alpine__head(self, browser_name):
+    async def test_alpine__head(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/alpine/head"
 
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+        page = await browser.new_page()
         await page.goto(single_comp_url)
 
         component_text = await page.locator('[x-data="alpine_test"]').text_content()
@@ -639,10 +640,10 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_alpine__body(self, browser_name):
+    async def test_alpine__body(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/alpine/body"
 
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+        page = await browser.new_page()
         await page.goto(single_comp_url)
 
         component_text = await page.locator('[x-data="alpine_test"]').text_content()
@@ -651,10 +652,10 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_alpine__body2(self, browser_name):
+    async def test_alpine__body2(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/alpine/body2"
 
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+        page = await browser.new_page()
         await page.goto(single_comp_url)
 
         component_text = await page.locator('[x-data="alpine_test"]').text_content()
@@ -663,10 +664,10 @@ class TestE2eDependencyRendering:
         await page.close()
 
     @with_playwright
-    async def test_alpine__invalid(self, browser_name):
+    async def test_alpine__invalid(self, browser: "Browser", browser_name: "BrowserType"):
         single_comp_url = TEST_SERVER_URL + "/alpine/invalid"
 
-        page: Page = await self.browser.new_page()  # type: ignore[attr-defined]
+        page = await browser.new_page()
         await page.goto(single_comp_url)
 
         component_text = await page.locator('[x-data="alpine_test"]').text_content()


### PR DESCRIPTION
After I had updated Playwright tests to run also against Firefox and Webkit ([in addition to Chromium](https://github.com/django-components/django-components/pull/1545)), now the CI test suite takes up to 20 mins ([see here](https://github.com/django-components/django-components/actions/runs/21290986762/job/61292365767)).

This PR should speed it up by reusing the browser instances. Before, the browser was re-opened and then closed before/after each test.