### PR TITLE
refactor: set links to be warnings in mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,9 @@ dev_addr: "127.0.0.1:9000"
 site_dir: site
 docs_dir: docs
 
+# TODO - There's about 15 errors preventing strict mode from being enabled.
+# strict: true
+
 watch:
   - src
   - docs
@@ -20,9 +23,12 @@ watch:
   - CHANGELOG.md
   - scripts
 
+# Validate internal / relative links
 validation:
+  omitted_files: warn
   absolute_links: warn
-  unrecognized_links: info
+  unrecognized_links: warn
+  anchors: warn
 
 theme:
   name: "material"
@@ -160,7 +166,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          import:
+          inventories:
             - https://docs.python.org/3.12/objects.inv
             - url: https://docs.djangoproject.com/en/5.2/_objects/
               base: https://docs.djangoproject.com/en/5.2/


### PR DESCRIPTION
Just cleaning out my local branch.

Mkdocs has a "strict" mode for CI, where the CLI process errors when there are any warnings.

Unfortunately there's still about 15 errors remaining, and these are related to various non-standard things we do in the documentation. Also `mkdocs` doesn't seem to offer any way to silence/ignore individual errors.

So I'm not enabling the strict mode, but at least updating the rest of the config.