### PR TITLE
refactor: fix Release not posted to Discord due to too long

### DIFF
--- a/.github/workflows/release-discord.yml
+++ b/.github/workflows/release-discord.yml
@@ -18,6 +18,12 @@ jobs:
           REPO: ${{ github.repository }}
           TS: ${{ github.event.release.published_at }}
         run: |
+          # Discord embed description limit is 4096 characters; truncate body to avoid webhook rejection
+          TRUNC_SUFFIX=$'\n\n_… See release link for full changelog._'
+          MAX_BODY=4000
+          if [ ${#BODY} -gt "$MAX_BODY" ]; then
+            BODY="${BODY:0:$MAX_BODY}${TRUNC_SUFFIX}"
+          fi
           payload=$(jq -n \
             --arg name "$NAME" \
             --arg url "$URL" \


### PR DESCRIPTION
Closes [discord] new release announcement not sent when text too long #1579

Releases  v0.146.0 and v0.147.0 were NOT sent to the Discord channel (see [this job](https://github.com/django-components/django-components/actions/runs/21587222502/job/62198229298)).

Likely due to the text of the Changelog being too long. This makes sure that the text is truncated to the max length.

The max length is 4096 characters (see `description`). [See Discord docs](https://discord.com/developers/docs/resources/message#embed-object-embed-limits)

<img width="1065" height="374" alt="Screenshot 2026-02-03 at 12 00 36" src="https://github.com/user-attachments/assets/7322c8fb-bb54-48c9-8a03-d942edaf8012" />
