### PR TITLE
fix: race condition where _template remains UNSET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,17 @@
             ]
     ```
 
+#### Fix
+
+- Fixed race condition where `Component._template` was not set correctly when rendering multiple components in parallel.
+
+    See [#1587](https://github.com/django-components/django-components/issues/1587)
+
+    ```python
+    class MyComponent(Component):
+        template = "<div>Hello, world!</div>"
+    ```
+
 #### Refactor
 
 - `Component.Media.js/css` now render BEFORE `Component.js/css`, instead of after.

--- a/src/django_components/component_media.py
+++ b/src/django_components/component_media.py
@@ -626,19 +626,19 @@ def _load_media(
             assert isinstance(self.media, MyMedia)
     ```
     """
+    # Skip base Component class
+    if get_import_path(comp_cls) == "django_components.component.Component":
+        return
+
     if asset_type == "template":
-        if comp_media.resolved_template:
+        # Retry if _template is still UNSET (race condition)
+        if comp_media.resolved_template and comp_media._template is not UNSET:
             return
-        else:
-            comp_media.resolved_template = True
+        comp_media.resolved_template = True
     elif asset_type == "non-template":
         if comp_media.resolved_files:
             return
         comp_media.resolved_files = True
-
-    # Do not resolve if this is a base class
-    if get_import_path(comp_cls) == "django_components.component.Component":
-        return
 
     comp_dirs = get_component_dirs()
 

--- a/src/django_components/template.py
+++ b/src/django_components/template.py
@@ -272,7 +272,8 @@ def _get_component_template(component: "Component") -> Template | None:
         # treat Templates AND their nodelists as IMMUTABLE.
         template = component.__class__._component_media._template  # type: ignore[attr-defined]
         # Race condition: treat UNSET as None
-        from django_components.component_media import UNSET
+        # See https://github.com/django-components/django-components/pull/1588
+        from django_components.component_media import UNSET  # noqa: PLC0415
 
         if template is UNSET:
             template = None

--- a/src/django_components/template.py
+++ b/src/django_components/template.py
@@ -271,6 +271,11 @@ def _get_component_template(component: "Component") -> Template | None:
         # NOTE: This is important to keep in mind, because the implication is that we should
         # treat Templates AND their nodelists as IMMUTABLE.
         template = component.__class__._component_media._template  # type: ignore[attr-defined]
+        # Race condition: treat UNSET as None
+        from django_components.component_media import UNSET
+
+        if template is UNSET:
+            template = None
         template_string = None
     # No template
     else:


### PR DESCRIPTION
See #1587.

Basically the idea is here to change the order of the logic a little bit, so the idempotent loading might happen twice, but a race condition does not lead to an error.

Test is just for illustration. I would not merge the test.