### PR TITLE
refactor: set deps_strategy="ignore" when nested in another component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,37 @@
 
 - `Component.Media.js/css` now render BEFORE `Component.js/css`, instead of after.
 
-    This is so that `Component.Media.js/css` behave more like dependencies.
+- **Rendering components in Python is now simpler: No explicit `deps_strategy` needed when nested**
+
+    When you pre-render a component in Python, and pass it into another component's `get_template_data()`,
+    you should pass `deps_strategy="ignore"` to the render function to avoid rendering the dependencies twice.
+
+    django-components now makes this easier for you.
+
+    When you call `Component.render()` from Python inside another component (e.g. in `get_template_data()`),
+    you no longer need to pass `deps_strategy="ignore"` to the inner Component. This is set automatically be default.
+
+    Top-level renders still default to `"document"`.
+    
+    See [issue #1463](https://github.com/django-components/django-components/issues/1463).
+
+    Before:
+
+    ```py
+    class Outer(Component):
+        def get_template_data(self, args, kwargs, slots, context):
+            content = Inner.render(deps_strategy="ignore")
+            return {"content": content}
+    ```
+
+    After:
+
+    ```py
+    class Outer(Component):
+        def get_template_data(self, args, kwargs, slots, context):
+            content = Inner.render()  # no deps_strategy needed!
+            return {"content": content}
+    ```
 
 ## v0.147.0
 

--- a/docs/concepts/advanced/html_fragments.md
+++ b/docs/concepts/advanced/html_fragments.md
@@ -44,8 +44,8 @@ A component is rendered as a "document" when:
 
 - It is embedded inside a template as [`{% component %}`](../../reference/template_tags.md#component)
 - It is rendered with [`Component.render()`](../../reference/api.md#django_components.Component.render)
-or [`Component.render_to_response()`](../../reference/api.md#django_components.Component.render_to_response)
-  with the `deps_strategy` kwarg set to `"document"` (default)
+  or [`Component.render_to_response()`](../../reference/api.md#django_components.Component.render_to_response)
+  with the `deps_strategy` kwarg set to `"document"` (default for top-level renders)
 
 Example:
 

--- a/docs/concepts/fundamentals/rendering_components.md
+++ b/docs/concepts/fundamentals/rendering_components.md
@@ -242,7 +242,7 @@ Button.render(
 - `kwargs` - Keyword arguments to pass to the component (as a dictionary)
 - `slots` - Slot content to pass to the component (as a dictionary)
 - `context` - Django context for rendering (can be a dictionary or a `Context` object)
-- `deps_strategy` - [Dependencies rendering strategy](#dependencies-rendering) (default: `"document"`)
+- `deps_strategy` - [Dependencies rendering strategy](#dependencies-rendering) (default: `"document"` for top-level; `"ignore"` when nested)
 - `request` - [HTTP request object](http_request.md), used for context processors (optional)
 
 All arguments are optional. If not provided, they default to empty values or sensible defaults.
@@ -344,7 +344,7 @@ Learn more about [Rendering JS / CSS](../advanced/rendering_js_css.md).
 
 There are six dependencies rendering strategies:
 
-- [`document`](../advanced/rendering_js_css.md#document) (default)
+- [`document`](../advanced/rendering_js_css.md#document) (default for top-level)
     - Smartly inserts JS / CSS into placeholders ([`{% component_js_dependencies %}`](../../reference/template_tags.md#component_js_dependencies)) or into `<head>` and `<body>` tags.
     - Requires the HTML to be rendered in a JS-enabled browser.
     - Inserts extra script for managing fragments.
@@ -363,7 +363,7 @@ There are six dependencies rendering strategies:
     - Insert JS / CSS after the rendered HTML.
     - Ignores the placeholders ([`{% component_js_dependencies %}`](../../reference/template_tags.md#component_js_dependencies)) and any `<head>`/`<body>` HTML tags.
     - No extra script loaded.
-- [`ignore`](../advanced/rendering_js_css.md#ignore)
+- [`ignore`](../advanced/rendering_js_css.md#ignore) (default when nested)
     - HTML is left as-is. You can still process it with a different strategy later with
       [`render_dependencies()`](../../reference/api.md#django_components.render_dependencies).
     - Used for inserting rendered HTML into other components.
@@ -433,7 +433,6 @@ class Button(Component):
         icon = Icon.render(
             context=context,
             args=["icon-name"],
-            deps_strategy="ignore",
         )
         # Update context with icon
         with context.update({"icon": icon}):

--- a/src/django_components/dependencies.py
+++ b/src/django_components/dependencies.py
@@ -799,12 +799,13 @@ def render_dependencies(content: TContent, strategy: DependenciesStrategy = "doc
     - `content` (str | bytes): The rendered HTML string that is searched for components, and
         into which we insert the JS and CSS tags. Required.
 
-    - `type` - Optional. Configure how to handle JS and CSS dependencies. Read more about
+    - `strategy` - Optional. Configure how to handle JS and CSS dependencies. Default is
+        ``"document"``. Read more about
         [Rendering strategies](../concepts/advanced/rendering_js_css.md#dependencies-strategies).
 
-        There are five render types:
+        There are six strategies:
 
-        - [`"document"`](../concepts/advanced/rendering_js_css.md#document) (default)
+        - [`"document"`](../concepts/advanced/rendering_js_css.md#document) (default for top-level)
             - Smartly inserts JS / CSS into placeholders or into `<head>` and `<body>` tags.
             - Inserts extra script to allow `fragment` types to work.
             - Assumes the HTML will be rendered in a JS-enabled browser.
@@ -820,6 +821,8 @@ def render_dependencies(content: TContent, strategy: DependenciesStrategy = "doc
         - [`"append"`](../concepts/advanced/rendering_js_css.md#append)
             - Insert JS / CSS after the rendered HTML.
             - No extra script loaded.
+        - [`"ignore"`](../concepts/advanced/rendering_js_css.md#ignore) (default when nested)
+            - Returns the content unchanged (no JS / CSS inserted).
 
     **Example:**
 


### PR DESCRIPTION
Closes https://github.com/django-components/django-components/issues/1463

This PR removes the need to pass `deps_strategy="ignore"` when rendering one component inside another:

Before:

```py
class Outer(Component):
    def get_template_data(self, args, kwargs, slots, context):
        content = Inner.render(deps_strategy="ignore")
        return {"content": content}
```

After:

```py
class Outer(Component):
    def get_template_data(self, args, kwargs, slots, context):
        content = Inner.render()  # no deps_strategy needed!
        return {"content": content}
```

<img width="1278" height="788" alt="Screenshot 2026-02-04 at 11 58 55" src="https://github.com/user-attachments/assets/20fb7e4d-f412-4186-b495-2b9b4a147347" />

