### PR TITLE
fix: memory leaks in CacheExtension.render_id_to_cache_key and context_processors_data WeakKeyDictionary

### DIFF
--- a/src/django_components/extensions/cache.py
+++ b/src/django_components/extensions/cache.py
@@ -184,12 +184,15 @@ class CacheExtension(ComponentExtension):
             return None
 
         cache_key = cache_instance.get_cache_key(ctx.args, ctx.kwargs, ctx.slots)
-        self.render_id_to_cache_key[ctx.component_id] = cache_key
 
         # If cache entry exists, return it. This will short-circuit the rendering process.
         cached_result = cache_instance.get_entry(cache_key)
         if cached_result is not None:
             return cached_result
+
+        # NOTE: Store the mapping only on cache miss, because on cache hit the rendering
+        # is short-circuited and on_component_rendered (which pops the entry) is never called.
+        self.render_id_to_cache_key[ctx.component_id] = cache_key
         return None
 
     # Save the rendered component to cache
@@ -199,7 +202,8 @@ class CacheExtension(ComponentExtension):
             return
 
         if ctx.error is not None:
+            self.render_id_to_cache_key.pop(ctx.component_id, None)
             return
 
-        cache_key = self.render_id_to_cache_key[ctx.component_id]
+        cache_key = self.render_id_to_cache_key.pop(ctx.component_id)
         cache_instance.set_entry(cache_key, ctx.result)

--- a/src/django_components/util/context.py
+++ b/src/django_components/util/context.py
@@ -1,6 +1,5 @@
 import copy
 from typing import TYPE_CHECKING, Any
-from weakref import WeakKeyDictionary
 
 from django.http import HttpRequest
 from django.template import Engine
@@ -10,9 +9,7 @@ from django.template.loader_tags import BlockContext
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-# We cache the context processors data for each request, so that we don't have to
-# generate it for each component.
-context_processors_data: WeakKeyDictionary[HttpRequest, dict[str, Any]] = WeakKeyDictionary()
+_REQUEST_ATTR = "_djc_context_processors_data"
 
 
 class CopiedDict(dict):
@@ -126,8 +123,12 @@ def _copy_block_context(block_context: BlockContext) -> BlockContext:
 # `RequestContext.bind_template()`, but without depending on a Template object.
 # See https://github.com/django/django/blame/2d34ebe49a25d0974392583d5bbd954baf742a32/django/template/context.py#L255
 def gen_context_processors_data(context: BaseContext, request: HttpRequest) -> dict[str, Any]:
-    if request in context_processors_data:
-        return context_processors_data[request].copy()
+    # NOTE: We cache the context processors data on the request object itself, so that
+    # we don't have to re-generate it for each component within the same request, and
+    # so the cache is automatically cleaned up when the request is garbage collected.
+    cached = getattr(request, _REQUEST_ATTR, None)
+    if cached is not None:
+        return cached.copy()
 
     # Reuse context processor data from RequestContext when Django has already run
     # bind_template() (e.g. when rendering a template that uses {% extends %}).
@@ -141,7 +142,7 @@ def gen_context_processors_data(context: BaseContext, request: HttpRequest) -> d
         except IndexError:
             existing = {}
         if existing:
-            context_processors_data[request] = existing
+            setattr(request, _REQUEST_ATTR, existing)
             return existing.copy()
 
     # TODO_REMOVE_IN_V2 - In v2, if we still support context processors,
@@ -164,6 +165,6 @@ def gen_context_processors_data(context: BaseContext, request: HttpRequest) -> d
         except TypeError as e:
             raise TypeError(f"Context processor {processor.__qualname__} didn't return a dictionary.") from e
 
-    context_processors_data[request] = processors_data
+    setattr(request, _REQUEST_ATTR, processors_data)
 
     return processors_data

--- a/tests/test_component_cache.py
+++ b/tests/test_component_cache.py
@@ -7,6 +7,8 @@ from django.template import Template
 from django.template.context import Context
 
 from django_components import Component, register
+from django_components.extension import extensions as extension_manager
+from django_components.extensions.cache import CacheExtension
 from django_components.testing import djc_test
 
 from .testutils import setup_test_config
@@ -347,3 +349,57 @@ class TestComponentCache:
                 kwargs={"input": "cake"},
                 slots={"content": lambda _ctx: "ONE"},
             )
+
+
+@djc_test(
+    django_settings={
+        "CACHES": {
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+        },
+    },
+)
+class TestCacheRenderIdCleanup:
+    def _get_cache_ext(self) -> CacheExtension:
+        for ext in extension_manager.extensions:
+            if isinstance(ext, CacheExtension):
+                return ext
+        raise RuntimeError("CacheExtension not found")
+
+    def test_render_id_cleaned_up(self):
+        class TestComponent(Component):
+            template = "Hello {{ name }}"
+
+            class Cache:
+                enabled = True
+
+            def get_template_data(self, args, kwargs, slots, context):
+                return {"name": kwargs.get("name", "world")}
+
+        cache_ext = self._get_cache_ext()
+
+        # Cache miss
+        TestComponent.render(kwargs={"name": "world"})
+        assert len(cache_ext.render_id_to_cache_key) == 0
+
+        # Cache hit
+        TestComponent.render(kwargs={"name": "world"})
+        assert len(cache_ext.render_id_to_cache_key) == 0
+
+    def test_render_id_cleaned_up_on_error(self):
+        class ErrorComponent(Component):
+            template = "Hello"
+
+            class Cache:
+                enabled = True
+
+            def on_render(self, context, template):
+                raise ValueError("deliberate error")
+
+        cache_ext = self._get_cache_ext()
+
+        with pytest.raises(ValueError, match="deliberate error"):
+            ErrorComponent.render()
+
+        assert len(cache_ext.render_id_to_cache_key) == 0

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,4 +1,6 @@
+import gc
 import tempfile
+import weakref
 from pathlib import Path
 from typing import cast
 
@@ -1114,6 +1116,24 @@ class TestContextProcessors:
 
         with pytest.raises(ValueError, match="Variable 'request' defined in component 'TestComponent' conflicts"):
             TestComponent.render(request=HttpRequest())
+
+    def test_request_is_gc_after_render(self):
+        class TestComponent(Component):
+            template: types.django_html = """Hello"""
+
+        request = HttpRequest()
+        ref = weakref.ref(request)
+
+        TestComponent.render(request=request)
+
+        del request
+        # Two passes: first collects the component (triggering cleanup of
+        # component_context_cache via weak ref finalizer), second collects the
+        # now-orphaned context snapshot that has internal reference cycles.
+        gc.collect()
+        gc.collect()
+
+        assert ref() is None
 
 
 @djc_test


### PR DESCRIPTION
See#1607 

1. Change dict read to .pop() in on_component_rendered so entries are removed after use. Also clean up on the error path.
2. Remove context_processors_data WeakKeyDictionary in favor of setting the context on the request itself.

Tests for reproduction mostly, can be dropped, but I would keep them.